### PR TITLE
Port lidar DEM depression/mount algorithms to pure-Rust WASM tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,35 @@ tools.mjs                        crates/geolibre-cli (main.rs)
                                    tool writes via std::fs to /work
 ```
 
+## GeoLibre-authored tools
+
+In addition to the whitebox suite, `geolibre-tools` ships pure-Rust ports of the
+DEM depression/mount algorithms from [`opengeos/lidar`](https://github.com/opengeos/lidar)
+(no GDAL, RichDEM, SciPy, or scikit-image dependency; they run in WASM):
+
+| Tool id | Source | What it does |
+|---|---|---|
+| `dem_filter` | `filtering.py` | Mean / median / Gaussian smoothing of a DEM. |
+| `extract_sinks` | `filling.py` | Wang & Liu fill, then group filled cells into sinks larger than `min_size`; emits sink/region/depth/filled rasters, an attribute CSV, and region polygons (`vector_output`, GeoJSON). |
+| `delineate_depressions` | `slicing.py` | Level-set slicing of a sink raster into a nested-depression hierarchy; emits id/level rasters, a CSV, and depression polygons (`vector_output`, GeoJSON). |
+| `delineate_mounts` | `mounts.py` | Flip the DEM, then run the sink + depression pipeline to delineate nested elevated features (rasters, CSV, and GeoJSON). |
+
+Typical chain (over the WASI `/work` filesystem or via paths):
+
+```text
+extract_sinks --input=dem.tif --output=sink.tif --min_size=100
+delineate_depressions --input=sink.tif --output=dep_id.tif --level_output=dep_level.tif
+```
+
+Depression filling reuses a port of whitebox's Wang & Liu priority-flood (kept
+inside `geolibre-tools` so the crate stays free of a `wbtools_oss` dependency).
+The morphological attributes (perimeter, axes, eccentricity, orientation) mirror
+`scikit-image`'s `regionprops`. The `vector_output` parameter polygonizes the
+label raster into GeoJSON (one feature per connected component, holes preserved,
+RFC 7946 winding) in the source CRS, with the attribute table joined onto each
+feature -- a pure-Rust replacement for the `gdal.Polygonize` + GeoPackage join
+in the Python original.
+
 ## Adding a new tool
 
 1. Add a module with a `wbcore::Tool` impl under `crates/geolibre-tools/src/`

--- a/crates/geolibre-tools/src/common.rs
+++ b/crates/geolibre-tools/src/common.rs
@@ -1,0 +1,129 @@
+//! Shared helpers for GeoLibre tools: raster input/output over file paths or
+//! in-memory (`memory://`) handles, and small numeric utilities.
+//!
+//! These mirror the private helpers in `raster_normalize.rs` but are shared so
+//! the LiDAR/DEM tools (filters, sink extraction, depression delineation) can
+//! reuse one implementation.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use serde_json::Value;
+use wbcore::{ToolArgs, ToolError};
+use wbraster::{memory_store, DataType, Raster, RasterFormat};
+
+/// Parses an optional string `output` parameter (absent / null / empty -> None).
+pub fn parse_optional_output<'a>(
+    args: &'a ToolArgs,
+    key: &str,
+) -> Result<Option<&'a str>, ToolError> {
+    match args.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(s)) if s.trim().is_empty() => Ok(None),
+        Some(Value::String(s)) => Ok(Some(s.as_str())),
+        Some(_) => Err(ToolError::Validation(format!(
+            "parameter '{key}' must be a string when provided"
+        ))),
+    }
+}
+
+/// Loads a raster from a file path or an in-memory (`memory://`) handle.
+pub fn load_input_raster(path: &str) -> Result<Raster, ToolError> {
+    if memory_store::raster_is_memory_path(path) {
+        let id = memory_store::raster_path_to_id(path)
+            .ok_or_else(|| ToolError::Validation("malformed in-memory raster path".to_string()))?;
+        let arc: Arc<Raster> = memory_store::get_raster_arc_by_id(id)
+            .ok_or_else(|| ToolError::Validation(format!("unknown in-memory raster id '{id}'")))?;
+        return Ok((*arc).clone());
+    }
+
+    Raster::read(path)
+        .map_err(|e| ToolError::Execution(format!("failed reading input raster: {e}")))
+}
+
+/// Writes `raster` to `output_path`, or stores it in memory and returns a
+/// `memory://` handle when no path is given.
+pub fn write_or_store_output(
+    raster: Raster,
+    output_path: Option<&str>,
+) -> Result<String, ToolError> {
+    match output_path {
+        Some(output_path) => {
+            if let Some(parent) = Path::new(output_path).parent() {
+                if !parent.as_os_str().is_empty() {
+                    std::fs::create_dir_all(parent).map_err(|e| {
+                        ToolError::Execution(format!("failed creating output directory: {e}"))
+                    })?;
+                }
+            }
+            let fmt = RasterFormat::for_output_path(output_path)
+                .map_err(|e| ToolError::Validation(format!("unsupported output path: {e}")))?;
+            raster
+                .write(output_path, fmt)
+                .map_err(|e| ToolError::Execution(format!("failed writing output raster: {e}")))?;
+            Ok(output_path.to_string())
+        }
+        None => {
+            let id = memory_store::put_raster(raster);
+            Ok(memory_store::make_raster_memory_path(&id))
+        }
+    }
+}
+
+/// Writes a plain-text artifact (e.g. a CSV attribute table) to a file path,
+/// creating parent directories as needed. In-memory output is not supported for
+/// text artifacts, so a path is required.
+pub fn write_text_output(text: &str, output_path: &str) -> Result<(), ToolError> {
+    if let Some(parent) = Path::new(output_path).parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                ToolError::Execution(format!("failed creating output directory: {e}"))
+            })?;
+        }
+    }
+    std::fs::write(output_path, text)
+        .map_err(|e| ToolError::Execution(format!("failed writing text output: {e}")))
+}
+
+/// Reads one band of a raster into a dense, row-major `f64` buffer. No-data
+/// cells are returned verbatim (the raster's `nodata` value), so callers should
+/// compare against `raster.nodata`.
+pub fn band_to_vec(raster: &Raster, band: isize) -> Vec<f64> {
+    let rows = raster.rows;
+    let cols = raster.cols;
+    let mut out = vec![0.0_f64; rows * cols];
+    for row in 0..rows {
+        for col in 0..cols {
+            out[row * cols + col] = raster.get(band, row as isize, col as isize);
+        }
+    }
+    out
+}
+
+/// Builds a new single-band raster that copies `template`'s geometry and CRS but
+/// uses the supplied data buffer, no-data value, and data type.
+pub fn raster_like_with_data(
+    template: &Raster,
+    data: Vec<f64>,
+    nodata: f64,
+    data_type: DataType,
+) -> Result<Raster, ToolError> {
+    let mut out = Raster::new_like(template);
+    out.nodata = nodata;
+    out.data_type = data_type;
+    let rows = out.rows;
+    let cols = out.cols;
+    if data.len() != rows * cols {
+        return Err(ToolError::Execution(format!(
+            "output buffer length {} does not match {rows}x{cols}",
+            data.len()
+        )));
+    }
+    for row in 0..rows {
+        for col in 0..cols {
+            out.set(0, row as isize, col as isize, data[row * cols + col])
+                .map_err(|e| ToolError::Execution(format!("failed writing cell: {e}")))?;
+        }
+    }
+    Ok(out)
+}

--- a/crates/geolibre-tools/src/delineate_depressions.rs
+++ b/crates/geolibre-tools/src/delineate_depressions.rs
@@ -1,0 +1,591 @@
+//! Nested-depression delineation via the level-set method, ported from
+//! `lidar`'s `slicing.py` (`levelSet`, `updateLevel`, `obj_to_level`,
+//! `DelineateDepressions`).
+//!
+//! Starting from a sink raster (elevations inside sinks, `0` elsewhere), each
+//! connected sink region is sliced from its highest elevation downward at a
+//! fixed `interval`. Every time a depression splits into two or more sub-basins
+//! a new, deeper-level depression is recorded, building a nested hierarchy. The
+//! tool emits a unique-id raster, a depression-level raster, and an attribute
+//! CSV.
+
+use std::collections::HashMap;
+
+use serde_json::{json, Map, Value};
+use wbcore::{
+    LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata, ToolParamSpec,
+    ToolRunResult,
+};
+use wbraster::DataType;
+
+use crate::common::{
+    band_to_vec, load_input_raster, parse_optional_output, raster_like_with_data, write_or_store_output,
+    write_text_output,
+};
+use crate::polygonize::{polygonize_to_geojson, PolygonizeParams};
+use crate::regions::{region_group, region_props, RegionProps};
+
+/// A single (possibly nested) depression.
+#[derive(Debug, Clone)]
+pub struct Depression {
+    pub id: i64,
+    pub level: i64,
+    pub count: u64,
+    pub size: f64,
+    pub volume: f64,
+    pub mean_depth: f64,
+    pub max_depth: f64,
+    pub min_elev: f64,
+    pub max_elev: f64,
+    pub in_nbr_id: Vec<i64>,
+    pub region_id: u32,
+    pub perimeter: f64,
+    pub major_axis: f64,
+    pub minor_axis: f64,
+    pub elongatedness: f64,
+    pub eccentricity: f64,
+    pub orientation: f64,
+    pub area_bbox_ratio: f64,
+}
+
+/// Builds a [`Depression`] from a region's properties at one slice level.
+// lidar divides orientation by the literal 3.1415 (not PI); kept for parity.
+#[allow(clippy::approx_constant)]
+fn make_dep(
+    obj: &RegionProps,
+    unique_id: i64,
+    level: i64,
+    region_id: u32,
+    resolution: f64,
+) -> Depression {
+    let count = obj.area as f64;
+    let res2 = resolution * resolution;
+    let max_depth = obj.max_intensity - obj.min_intensity;
+    let mean_depth = (obj.max_intensity * count - obj.sum_intensity) / count;
+    let mut minor_axis = obj.minor_axis_length * resolution;
+    if minor_axis == 0.0 {
+        minor_axis = resolution;
+    }
+    let major_axis = obj.major_axis_length * resolution;
+    Depression {
+        id: unique_id,
+        level,
+        count: obj.area,
+        size: count * res2,
+        volume: mean_depth * count * res2,
+        mean_depth,
+        max_depth,
+        min_elev: obj.min_intensity,
+        max_elev: obj.max_intensity,
+        in_nbr_id: Vec::new(),
+        region_id,
+        perimeter: obj.perimeter * resolution,
+        major_axis,
+        minor_axis,
+        elongatedness: major_axis / minor_axis,
+        eccentricity: obj.eccentricity,
+        orientation: obj.orientation / 3.1415 * 180.0,
+        area_bbox_ratio: obj.extent,
+    }
+}
+
+/// Writes `unique_id` into `level_img` at every cell of region `label`.
+fn write_label(level_img: &mut [f64], labels: &[u32], label: u32, unique_id: i64) {
+    for (i, &l) in labels.iter().enumerate() {
+        if l == label {
+            level_img[i] = unique_id as f64;
+        }
+    }
+}
+
+/// Level-set identification of nested depressions within one region.
+///
+/// `img` is the region's elevation subimage (row-major, `0` outside the region
+/// mask). `interval` is negative (top-down). Returns the region-local object-id
+/// image and the depressions found, with `id` values starting at `obj_uid + 1`.
+#[allow(clippy::too_many_arguments)]
+pub fn level_set(
+    img: &[f64],
+    rows: usize,
+    cols: usize,
+    region_id: u32,
+    obj_uid: i64,
+    min_size: u64,
+    interval: f64,
+    resolution: f64,
+) -> (Vec<f64>, Vec<Depression>) {
+    let n = rows * cols;
+    let mut level_img = vec![0.0_f64; n];
+
+    // Background (0) becomes a large sentinel; elevations are positive.
+    let max_elev = img
+        .iter()
+        .cloned()
+        .fold(f64::NEG_INFINITY, f64::max);
+    let big = sentinel_nodata(max_elev);
+    let mut work: Vec<f64> = img.iter().map(|&v| if v == 0.0 { big } else { v }).collect();
+    let min_elev = work.iter().cloned().fold(f64::INFINITY, f64::min);
+
+    let mut dep_list: Vec<Depression> = Vec::new();
+    let mut unique_id = obj_uid;
+
+    // Degenerate 1-pixel-wide region: one depression over the elevation cells.
+    // (The Python special-case here computes garbage stats over the bbox; we
+    // compute sensible stats over the actual region instead.)
+    if rows == 1 || cols == 1 {
+        let mask: Vec<bool> = img.iter().map(|&v| v != 0.0).collect();
+        let labels: Vec<u32> = mask.iter().map(|&m| if m { 1 } else { 0 }).collect();
+        let props = region_props(&labels, 1, img, rows, cols);
+        if let Some(obj) = props.first() {
+            unique_id += 1;
+            dep_list.push(make_dep(obj, unique_id, 1, region_id, resolution));
+            write_label(&mut level_img, &labels, 1, unique_id);
+        }
+        return (level_img, dep_list);
+    }
+
+    let mut parent_ids: HashMap<i64, u32> = HashMap::new();
+    let mut nbr_ids: HashMap<i64, Vec<usize>> = HashMap::new();
+
+    let mut elev = max_elev;
+    while elev > min_elev {
+        for v in work.iter_mut() {
+            if *v > elev {
+                *v = 0.0;
+            }
+        }
+        let (labels, count) = region_group(&work, rows, cols, min_size, big);
+        if count == 0 {
+            break;
+        }
+        let objects = region_props(&labels, count, &work, rows, cols);
+
+        for (i, obj) in objects.iter().enumerate() {
+            let (row, col) = obj.first_coord;
+            if parent_ids.is_empty() {
+                // First (maximum-extent) depression of the region.
+                unique_id += 1;
+                dep_list.push(make_dep(obj, unique_id, 1, region_id, resolution));
+                parent_ids.insert(unique_id, 0);
+                nbr_ids.insert(unique_id, Vec::new());
+                write_label(&mut level_img, &labels, obj.label, unique_id);
+            } else {
+                let parent_id = level_img[row * cols + col] as i64;
+                if let Some(cnt) = parent_ids.get_mut(&parent_id) {
+                    *cnt += 1;
+                    nbr_ids.entry(parent_id).or_default().push(i);
+                }
+                // parent_id not in parent_ids (already split & popped, or
+                // background) is skipped, matching the non-crashing assumption.
+            }
+        }
+
+        // Promote any parent that split into two or more children this slice.
+        let keys: Vec<i64> = parent_ids.keys().cloned().collect();
+        for key in keys {
+            let split = parent_ids.get(&key).copied().unwrap_or(0) > 1;
+            if split {
+                let children = nbr_ids.get(&key).cloned().unwrap_or_default();
+                for new_key in children {
+                    let obj = &objects[new_key];
+                    unique_id += 1;
+                    dep_list.push(make_dep(obj, unique_id, 1, region_id, resolution));
+                    let parent_idx = (key - 1 - obj_uid) as usize;
+                    if let Some(parent) = dep_list.get_mut(parent_idx) {
+                        parent.in_nbr_id.push(unique_id);
+                    }
+                    parent_ids.insert(unique_id, 0);
+                    nbr_ids.insert(unique_id, Vec::new());
+                    write_label(&mut level_img, &labels, obj.label, unique_id);
+                }
+                parent_ids.remove(&key);
+            } else {
+                parent_ids.insert(key, 0);
+                nbr_ids.insert(key, Vec::new());
+            }
+        }
+
+        elev += interval; // interval is negative
+    }
+
+    update_level(&mut dep_list, obj_uid);
+    (level_img, dep_list)
+}
+
+/// Assigns hierarchy levels: a leaf is level 1; a parent is one more than its
+/// deepest child. Mirrors `slicing.py` `updateLevel`.
+fn update_level(dep_list: &mut [Depression], obj_uid: i64) {
+    let levels_by_index = |dep_list: &[Depression], id: i64| -> i64 {
+        let idx = (id - 1 - obj_uid) as usize;
+        dep_list.get(idx).map(|d| d.level).unwrap_or(0)
+    };
+    for i in (0..dep_list.len()).rev() {
+        if dep_list[i].in_nbr_id.is_empty() {
+            dep_list[i].level = 1;
+        } else {
+            let mut max_child = 0;
+            for &id in &dep_list[i].in_nbr_id.clone() {
+                let l = levels_by_index(dep_list, id);
+                if l > max_child {
+                    max_child = l;
+                }
+            }
+            dep_list[i].level = max_child + 1;
+        }
+    }
+}
+
+/// `lidar`'s `get_min_max_nodata` sentinel: `10^(floor(log10(max))+2) - 1`.
+fn sentinel_nodata(max_elev: f64) -> f64 {
+    if max_elev <= 0.0 {
+        return 1.0e9;
+    }
+    let exp = max_elev.log10().floor() as i32 + 2;
+    10.0_f64.powi(exp) - 1.0
+}
+
+/// Converts a region-local object-id image to a depression-level image using
+/// the global depression list (`slicing.py` `obj_to_level`).
+fn obj_to_level(obj_img: &[f64], global: &[Depression]) -> Vec<f64> {
+    obj_img
+        .iter()
+        .map(|&v| {
+            let id = v as i64;
+            if id > 0 {
+                global
+                    .get((id - 1) as usize)
+                    .map(|d| d.level as f64)
+                    .unwrap_or(0.0)
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+/// Result of delineation: full-image id and level rasters plus the depression
+/// list. Buffers are row-major of length `rows * cols`.
+pub struct DelineateResult {
+    pub obj_image: Vec<f64>,
+    pub level_image: Vec<f64>,
+    pub depressions: Vec<Depression>,
+}
+
+/// Core of `DelineateDepressions`, independent of raster I/O.
+///
+/// `sink` is the sink raster (positive elevations inside sinks, `0` elsewhere).
+/// `interval` is the positive slicing interval (negated internally).
+pub fn delineate_core(
+    sink: &[f64],
+    rows: usize,
+    cols: usize,
+    resolution: f64,
+    min_size: u64,
+    interval: f64,
+) -> DelineateResult {
+    let neg_interval = -interval.abs();
+
+    // Elevation image with 0 background (matches lidar's mutated working array).
+    let elev_img: Vec<f64> = sink.iter().map(|&v| if v > 0.0 { v } else { 0.0 }).collect();
+    let (labels, count) = region_group(&elev_img, rows, cols, min_size, 0.0);
+    let regions = region_props(&labels, count, &elev_img, rows, cols);
+
+    let mut obj_image = vec![0.0_f64; rows * cols];
+    let mut level_image = vec![0.0_f64; rows * cols];
+    let mut global: Vec<Depression> = Vec::new();
+    let mut obj_uid: i64 = 0;
+
+    for region in &regions {
+        let (min_row, min_col, max_row, max_col) = region.bbox;
+        let br = max_row - min_row;
+        let bc = max_col - min_col;
+
+        // Region-local elevation subimage (0 outside the region mask).
+        let mut img = vec![0.0_f64; br * bc];
+        for r in 0..br {
+            for c in 0..bc {
+                let gi = (min_row + r) * cols + (min_col + c);
+                if labels[gi] == region.label {
+                    img[r * bc + c] = elev_img[gi];
+                }
+            }
+        }
+
+        let (out_obj, dep_list) = level_set(
+            &img,
+            br,
+            bc,
+            region.label,
+            obj_uid,
+            min_size,
+            neg_interval,
+            resolution,
+        );
+
+        obj_uid += dep_list.len() as i64;
+        global.extend(dep_list);
+        let level_obj = obj_to_level(&out_obj, &global);
+
+        // Composite region buffers back into the full image.
+        for r in 0..br {
+            for c in 0..bc {
+                let gi = (min_row + r) * cols + (min_col + c);
+                let oid = out_obj[r * bc + c];
+                if oid > 0.0 {
+                    obj_image[gi] = oid;
+                }
+                let lvl = level_obj[r * bc + c];
+                if lvl > 0.0 {
+                    level_image[gi] = lvl;
+                }
+            }
+        }
+    }
+
+    DelineateResult {
+        obj_image,
+        level_image,
+        depressions: global,
+    }
+}
+
+/// Builds the depression attribute CSV emitted by `DelineateDepressions`.
+pub fn depression_csv(deps: &[Depression]) -> String {
+    let mut csv = String::from(
+        "id,level,count,area,volume,avg_depth,max_depth,min_elev,max_elev,children_id,\
+         region_id,perimeter,major_axis,minor_axis,elongatedness,eccentricity,orientation,\
+         area_bbox_ratio\n",
+    );
+    for d in deps {
+        let children = if d.in_nbr_id.is_empty() {
+            "[]".to_string()
+        } else {
+            let parts: Vec<String> = d.in_nbr_id.iter().map(|id| id.to_string()).collect();
+            format!("[{}]", parts.join(":"))
+        };
+        csv.push_str(&format!(
+            "{},{},{},{:.2},{:.2},{:.2},{:.2},{:.2},{:.2},{},{},{:.2},{:.2},{:.2},{:.2},{:.2},{:.2},{:.2}\n",
+            d.id,
+            d.level,
+            d.count,
+            d.size,
+            d.volume,
+            d.mean_depth,
+            d.max_depth,
+            d.min_elev,
+            d.max_elev,
+            children,
+            d.region_id,
+            d.perimeter,
+            d.major_axis,
+            d.minor_axis,
+            d.elongatedness,
+            d.eccentricity,
+            d.orientation,
+            d.area_bbox_ratio,
+        ));
+    }
+    csv
+}
+
+/// Builds a depression attribute table keyed by depression id, for joining onto
+/// polygonized features (mirrors the [`depression_csv`] columns).
+pub fn depression_props_map(deps: &[Depression]) -> HashMap<i64, Map<String, Value>> {
+    let mut map = HashMap::new();
+    for d in deps {
+        let children: Vec<i64> = d.in_nbr_id.clone();
+        let mut attrs = Map::new();
+        attrs.insert("id".to_string(), json!(d.id));
+        attrs.insert("level".to_string(), json!(d.level));
+        attrs.insert("count".to_string(), json!(d.count));
+        attrs.insert("area".to_string(), json!(d.size));
+        attrs.insert("volume".to_string(), json!(d.volume));
+        attrs.insert("avg_depth".to_string(), json!(d.mean_depth));
+        attrs.insert("max_depth".to_string(), json!(d.max_depth));
+        attrs.insert("min_elev".to_string(), json!(d.min_elev));
+        attrs.insert("max_elev".to_string(), json!(d.max_elev));
+        attrs.insert("children_id".to_string(), json!(children));
+        attrs.insert("region_id".to_string(), json!(d.region_id));
+        attrs.insert("perimeter".to_string(), json!(d.perimeter));
+        attrs.insert("major_axis".to_string(), json!(d.major_axis));
+        attrs.insert("minor_axis".to_string(), json!(d.minor_axis));
+        attrs.insert("elongatedness".to_string(), json!(d.elongatedness));
+        attrs.insert("eccentricity".to_string(), json!(d.eccentricity));
+        attrs.insert("orientation".to_string(), json!(d.orientation));
+        attrs.insert("area_bbox_ratio".to_string(), json!(d.area_bbox_ratio));
+        map.insert(d.id, attrs);
+    }
+    map
+}
+
+/// Delineates nested depressions from a sink raster (`lidar` `DelineateDepressions`).
+pub struct DelineateDepressionsTool;
+
+impl Tool for DelineateDepressionsTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "delineate_depressions",
+            display_name: "Delineate Depressions",
+            summary: "Delineate nested depressions from a sink raster using the level-set method (lidar slicing.py).",
+            category: ToolCategory::Hydrology,
+            license_tier: LicenseTier::Open,
+            params: vec![
+                ToolParamSpec {
+                    name: "input",
+                    description: "Input sink raster (e.g. the output of extract_sinks).",
+                    required: true,
+                },
+                ToolParamSpec {
+                    name: "output",
+                    description: "Optional depression-id raster path. If omitted, stored in memory.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "level_output",
+                    description: "Optional output path for the depression-level raster.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "csv_output",
+                    description: "Optional output path for the depression attribute CSV.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "vector_output",
+                    description: "Optional output path for depression polygons as GeoJSON (attributes joined).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "min_size",
+                    description: "Minimum number of pixels for a depression (default 10).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "min_depth",
+                    description: "Minimum depression depth (accepted for compatibility; unused, matching lidar).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "interval",
+                    description: "Slicing interval for the level-set method (default 0.3).",
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        if args.get("input").and_then(Value::as_str).is_none() {
+            return Err(ToolError::Validation(
+                "missing required string parameter 'input'".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = args
+            .get("input")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::Validation("missing required parameter 'input'".to_string()))?;
+        let output = parse_optional_output(args, "output")?;
+        let level_output = parse_optional_output(args, "level_output")?;
+        let csv_output = parse_optional_output(args, "csv_output")?;
+        let vector_output = parse_optional_output(args, "vector_output")?;
+        let min_size = args.get("min_size").and_then(Value::as_u64).unwrap_or(10);
+        let interval = args.get("interval").and_then(Value::as_f64).unwrap_or(0.3);
+
+        let raster = load_input_raster(input)?;
+        let rows = raster.rows;
+        let cols = raster.cols;
+        let resolution = raster.cell_size_x;
+        let sink = band_to_vec(&raster, 0);
+
+        ctx.progress.info("slicing depressions (level-set)");
+        let result = delineate_core(&sink, rows, cols, resolution, min_size, interval);
+        ctx.progress.progress(0.8);
+
+        let mut outputs = std::collections::BTreeMap::new();
+
+        if let Some(path) = vector_output {
+            let pmap = depression_props_map(&result.depressions);
+            let geojson = polygonize_to_geojson(&PolygonizeParams {
+                labels: &result.obj_image,
+                rows,
+                cols,
+                x_min: raster.x_min,
+                y_max: raster.y_max(),
+                cell_size_x: raster.cell_size_x,
+                cell_size_y: raster.cell_size_y,
+                epsg: raster.crs.epsg,
+                props_by_id: &pmap,
+            });
+            write_text_output(&geojson, path)?;
+            outputs.insert("vector".to_string(), json!(path));
+        }
+
+        let obj_raster = raster_like_with_data(&raster, result.obj_image, 0.0, DataType::I32)?;
+        let obj_path = write_or_store_output(obj_raster, output)?;
+        outputs.insert("output".to_string(), json!(obj_path));
+
+        if let Some(path) = level_output {
+            let r = raster_like_with_data(&raster, result.level_image, 0.0, DataType::I32)?;
+            outputs.insert("level".to_string(), json!(write_or_store_output(r, Some(path))?));
+        }
+        if let Some(path) = csv_output {
+            write_text_output(&depression_csv(&result.depressions), path)?;
+            outputs.insert("csv".to_string(), json!(path));
+        }
+
+        outputs.insert("depressions".to_string(), json!(result.depressions.len()));
+        ctx.progress.progress(1.0);
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_basin_one_depression() {
+        // A 6x6 sink that is one simple bowl: a single depression, level 1.
+        let rows = 6;
+        let cols = 6;
+        let mut sink = vec![0.0_f64; rows * cols];
+        for r in 1..5 {
+            for c in 1..5 {
+                // Bowl: deeper in the middle.
+                let d = ((r as f64 - 2.5).abs()).max((c as f64 - 2.5).abs());
+                sink[r * cols + c] = 5.0 + d; // 5..7
+            }
+        }
+        let result = delineate_core(&sink, rows, cols, 1.0, 1, 0.3);
+        assert!(!result.depressions.is_empty());
+        // The maximum-extent depression covers the whole basin.
+        assert_eq!(result.depressions[0].region_id, 1);
+        assert!(result.depressions[0].count >= 1);
+    }
+
+    #[test]
+    fn two_basins_split_into_nested_hierarchy() {
+        // Two pits joined by a saddle: top-level depression splits into two,
+        // giving a parent at level 2 with two level-1 children.
+        let rows = 5;
+        let cols = 9;
+        let mut sink = vec![0.0_f64; rows * cols];
+        // Fill a connected sink region; two deep wells at columns 2 and 6.
+        for r in 1..4 {
+            for c in 1..8 {
+                sink[r * cols + c] = 10.0;
+            }
+        }
+        for r in 1..4 {
+            sink[r * cols + 2] = 6.0; // well A
+            sink[r * cols + 6] = 6.0; // well B
+        }
+        let result = delineate_core(&sink, rows, cols, 1.0, 1, 1.0);
+        let max_level = result.depressions.iter().map(|d| d.level).max().unwrap_or(0);
+        assert!(max_level >= 2, "expected a nested hierarchy, got level {max_level}");
+    }
+}

--- a/crates/geolibre-tools/src/delineate_mounts.rs
+++ b/crates/geolibre-tools/src/delineate_mounts.rs
@@ -1,0 +1,215 @@
+//! Delineation of the nested hierarchy of elevated features (mounts), ported
+//! from `lidar`'s `mounts.py`.
+//!
+//! A mount is an inverted depression: flip the DEM, extract sinks on the flipped
+//! surface, then delineate nested depressions. The output id/level rasters
+//! describe the mount hierarchy of the original DEM.
+
+use serde_json::{json, Value};
+use wbcore::{
+    LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata, ToolParamSpec,
+    ToolRunResult,
+};
+use wbraster::DataType;
+
+use crate::common::{
+    band_to_vec, load_input_raster, parse_optional_output, raster_like_with_data, write_or_store_output,
+    write_text_output,
+};
+use crate::delineate_depressions::{delineate_core, depression_csv, depression_props_map};
+use crate::extract_sinks::extract_sinks_core;
+use crate::polygonize::{polygonize_to_geojson, PolygonizeParams};
+
+/// Flips a DEM so that peaks become pits: `flipped = -dem + max + delta`.
+/// No-data cells are preserved (the Python original mishandles them; we keep
+/// them as no-data).
+pub fn flip_dem(dem: &[f64], nodata: f64, delta: f64) -> Vec<f64> {
+    let max_elev = dem
+        .iter()
+        .cloned()
+        .filter(|&v| v != nodata)
+        .fold(f64::NEG_INFINITY, f64::max);
+    dem.iter()
+        .map(|&v| if v == nodata { nodata } else { -v + max_elev + delta })
+        .collect()
+}
+
+/// Delineates the nested hierarchy of mounts in a DEM (`lidar` `DelineateMounts`).
+pub struct DelineateMountsTool;
+
+impl Tool for DelineateMountsTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "delineate_mounts",
+            display_name: "Delineate Mounts",
+            summary: "Delineate the nested hierarchy of elevated features (mounts) in a DEM (lidar mounts.py).",
+            category: ToolCategory::Hydrology,
+            license_tier: LicenseTier::Open,
+            params: vec![
+                ToolParamSpec {
+                    name: "input",
+                    description: "Input DEM raster file path.",
+                    required: true,
+                },
+                ToolParamSpec {
+                    name: "output",
+                    description: "Optional mount-id raster path. If omitted, stored in memory.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "level_output",
+                    description: "Optional output path for the mount-level raster.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "csv_output",
+                    description: "Optional output path for the mount attribute CSV.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "vector_output",
+                    description: "Optional output path for mount polygons as GeoJSON (attributes joined).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "min_size",
+                    description: "Minimum number of pixels for a mount (default 10).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "min_height",
+                    description: "Minimum mount height (accepted for compatibility; unused, matching lidar).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "interval",
+                    description: "Slicing interval for the level-set method (default 0.3).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "delta",
+                    description: "Base value added when flipping the DEM (default 100).",
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        if args.get("input").and_then(Value::as_str).is_none() {
+            return Err(ToolError::Validation(
+                "missing required string parameter 'input'".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = args
+            .get("input")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::Validation("missing required parameter 'input'".to_string()))?;
+        let output = parse_optional_output(args, "output")?;
+        let level_output = parse_optional_output(args, "level_output")?;
+        let csv_output = parse_optional_output(args, "csv_output")?;
+        let vector_output = parse_optional_output(args, "vector_output")?;
+        let min_size = args.get("min_size").and_then(Value::as_u64).unwrap_or(10);
+        let interval = args.get("interval").and_then(Value::as_f64).unwrap_or(0.3);
+        let delta = args.get("delta").and_then(Value::as_f64).unwrap_or(100.0);
+
+        let raster = load_input_raster(input)?;
+        let rows = raster.rows;
+        let cols = raster.cols;
+        let nodata = raster.nodata;
+        let resolution = raster.cell_size_x;
+        let dem = band_to_vec(&raster, 0);
+
+        ctx.progress.info("flipping DEM");
+        let flipped = flip_dem(&dem, nodata, delta);
+
+        ctx.progress.info("extracting sinks on flipped DEM");
+        let sinks = extract_sinks_core(&flipped, rows, cols, nodata, min_size, 0.0);
+        ctx.progress.progress(0.5);
+
+        ctx.progress.info("delineating nested mounts");
+        let result = delineate_core(&sinks.sink, rows, cols, resolution, min_size, interval);
+        ctx.progress.progress(0.9);
+
+        let mut outputs = std::collections::BTreeMap::new();
+
+        if let Some(path) = vector_output {
+            let pmap = depression_props_map(&result.depressions);
+            let geojson = polygonize_to_geojson(&PolygonizeParams {
+                labels: &result.obj_image,
+                rows,
+                cols,
+                x_min: raster.x_min,
+                y_max: raster.y_max(),
+                cell_size_x: raster.cell_size_x,
+                cell_size_y: raster.cell_size_y,
+                epsg: raster.crs.epsg,
+                props_by_id: &pmap,
+            });
+            write_text_output(&geojson, path)?;
+            outputs.insert("vector".to_string(), json!(path));
+        }
+
+        let obj_raster = raster_like_with_data(&raster, result.obj_image, 0.0, DataType::I32)?;
+        let obj_path = write_or_store_output(obj_raster, output)?;
+        outputs.insert("output".to_string(), json!(obj_path));
+
+        if let Some(path) = level_output {
+            let r = raster_like_with_data(&raster, result.level_image, 0.0, DataType::I32)?;
+            outputs.insert("level".to_string(), json!(write_or_store_output(r, Some(path))?));
+        }
+        if let Some(path) = csv_output {
+            write_text_output(&depression_csv(&result.depressions), path)?;
+            outputs.insert("csv".to_string(), json!(path));
+        }
+
+        outputs.insert("mounts".to_string(), json!(result.depressions.len()));
+        ctx.progress.progress(1.0);
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flip_inverts_relief() {
+        let nodata = -9999.0;
+        let dem = vec![1.0, 2.0, 3.0, nodata];
+        let flipped = flip_dem(&dem, nodata, 100.0);
+        // max is 3; flipped = -v + 3 + 100.
+        assert_eq!(flipped[0], 102.0);
+        assert_eq!(flipped[2], 100.0);
+        assert_eq!(flipped[3], nodata);
+        // Relief is inverted: the lowest cell becomes the highest.
+        assert!(flipped[0] > flipped[2]);
+    }
+
+    #[test]
+    fn detects_a_mount() {
+        // A plateau with a central graded peak: flipping makes it a pit with
+        // relief (a flat-topped peak would flip to a flat pit and produce no
+        // slices, matching the Python behavior).
+        let rows = 7;
+        let cols = 7;
+        let nodata = -9999.0;
+        let mut dem = vec![1.0; rows * cols];
+        for r in 1..6 {
+            for c in 1..6 {
+                let cheb = (r as i64 - 3).abs().max((c as i64 - 3).abs()) as f64;
+                dem[r * cols + c] = 4.0 - cheb; // peak 4 at center, sloping to 2
+            }
+        }
+        let result = {
+            let flipped = flip_dem(&dem, nodata, 100.0);
+            let sinks = extract_sinks_core(&flipped, rows, cols, nodata, 1, 0.0);
+            delineate_core(&sinks.sink, rows, cols, 1.0, 1, 1.0)
+        };
+        assert!(!result.depressions.is_empty());
+    }
+}

--- a/crates/geolibre-tools/src/dem_filter.rs
+++ b/crates/geolibre-tools/src/dem_filter.rs
@@ -1,0 +1,286 @@
+//! DEM smoothing filters, ported from `lidar`'s `filtering.py`
+//! (`MeanFilter`, `MedianFilter`, `GaussianFilter`).
+//!
+//! These mirror the `scipy.ndimage` routines the Python package uses: a box
+//! `convolve` (mean), `median_filter`, and a separable `gaussian_filter`, all
+//! with the SciPy default `reflect` boundary mode. As in the Python code the
+//! filter runs over raw cell values; the no-data tag is preserved on the output.
+
+use serde_json::{json, Value};
+use wbcore::{
+    LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata, ToolParamSpec,
+    ToolRunResult,
+};
+
+use crate::common::{
+    band_to_vec, load_input_raster, parse_optional_output, raster_like_with_data,
+    write_or_store_output,
+};
+
+/// Smooths a DEM with a mean, median, or Gaussian filter.
+pub struct DemFilterTool;
+
+impl Tool for DemFilterTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "dem_filter",
+            display_name: "DEM Filter",
+            summary: "Smooth a DEM with a mean, median, or Gaussian filter (lidar filtering.py).",
+            category: ToolCategory::Raster,
+            license_tier: LicenseTier::Open,
+            params: vec![
+                ToolParamSpec {
+                    name: "input",
+                    description: "Input DEM raster file path.",
+                    required: true,
+                },
+                ToolParamSpec {
+                    name: "output",
+                    description: "Optional output raster path. If omitted, the result is stored in memory.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "filter",
+                    description: "Filter type: 'mean', 'median', or 'gaussian' (default 'mean').",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "kernel_size",
+                    description: "Window size in pixels for mean/median filters (default 3).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "sigma",
+                    description: "Standard deviation for the Gaussian filter (default 1.0).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "band",
+                    description: "1-based band to filter (default 1).",
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        if args.get("input").and_then(Value::as_str).is_none() {
+            return Err(ToolError::Validation(
+                "missing required string parameter 'input'".to_string(),
+            ));
+        }
+        if let Some(f) = args.get("filter").and_then(Value::as_str) {
+            match f.to_lowercase().as_str() {
+                "mean" | "median" | "gaussian" => {}
+                other => {
+                    return Err(ToolError::Validation(format!(
+                        "unknown filter '{other}' (expected mean, median, or gaussian)"
+                    )))
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = args
+            .get("input")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::Validation("missing required parameter 'input'".to_string()))?;
+        let output = parse_optional_output(args, "output")?;
+        let filter = args
+            .get("filter")
+            .and_then(Value::as_str)
+            .unwrap_or("mean")
+            .to_lowercase();
+        let kernel_size = args
+            .get("kernel_size")
+            .and_then(Value::as_u64)
+            .unwrap_or(3)
+            .max(1) as usize;
+        let sigma = args.get("sigma").and_then(Value::as_f64).unwrap_or(1.0);
+        let band_1based = args.get("band").and_then(Value::as_u64).unwrap_or(1).max(1);
+        let band = (band_1based - 1) as isize;
+
+        let raster = load_input_raster(input)?;
+        if band as usize >= raster.bands {
+            return Err(ToolError::Validation(format!(
+                "band {band_1based} out of range (raster has {} band(s))",
+                raster.bands
+            )));
+        }
+
+        let rows = raster.rows;
+        let cols = raster.cols;
+        let nodata = raster.nodata;
+        let src = band_to_vec(&raster, band);
+
+        ctx.progress.info(&format!("applying {filter} filter"));
+        let filtered = match filter.as_str() {
+            "mean" => mean_filter(&src, rows, cols, kernel_size),
+            "median" => median_filter(&src, rows, cols, kernel_size),
+            "gaussian" => gaussian_filter(&src, rows, cols, sigma),
+            _ => unreachable!("validate() restricts the filter type"),
+        };
+        ctx.progress.progress(1.0);
+
+        let out_raster = raster_like_with_data(&raster, filtered, nodata, raster.data_type)?;
+        let out_path = write_or_store_output(out_raster, output)?;
+
+        let mut outputs = std::collections::BTreeMap::new();
+        outputs.insert("output".to_string(), json!(out_path));
+        outputs.insert("filter".to_string(), json!(filter));
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+/// Reflects an index into `[0, n)` using SciPy's `reflect` mode (edge value
+/// duplicated): `-1 -> 0`, `n -> n-1`.
+fn reflect(mut i: isize, n: usize) -> usize {
+    if n == 1 {
+        return 0;
+    }
+    let n = n as isize;
+    loop {
+        if i < 0 {
+            i = -1 - i;
+        } else if i >= n {
+            i = 2 * n - 1 - i;
+        } else {
+            break;
+        }
+    }
+    i as usize
+}
+
+/// Box mean filter (`scipy.ndimage.convolve` with a uniform `k x k` kernel).
+fn mean_filter(src: &[f64], rows: usize, cols: usize, k: usize) -> Vec<f64> {
+    let mut out = vec![0.0_f64; rows * cols];
+    let radius = (k / 2) as isize;
+    let norm = 1.0 / (k * k) as f64;
+    for r in 0..rows {
+        for c in 0..cols {
+            let mut acc = 0.0;
+            for dr in -radius..=radius {
+                let rr = reflect(r as isize + dr, rows);
+                for dc in -radius..=radius {
+                    let cc = reflect(c as isize + dc, cols);
+                    acc += src[rr * cols + cc];
+                }
+            }
+            out[r * cols + c] = acc * norm;
+        }
+    }
+    out
+}
+
+/// Median filter (`scipy.ndimage.median_filter`, `k x k` window, reflect mode).
+fn median_filter(src: &[f64], rows: usize, cols: usize, k: usize) -> Vec<f64> {
+    let mut out = vec![0.0_f64; rows * cols];
+    let radius = (k / 2) as isize;
+    let mut window: Vec<f64> = Vec::with_capacity(k * k);
+    for r in 0..rows {
+        for c in 0..cols {
+            window.clear();
+            for dr in -radius..=radius {
+                let rr = reflect(r as isize + dr, rows);
+                for dc in -radius..=radius {
+                    let cc = reflect(c as isize + dc, cols);
+                    window.push(src[rr * cols + cc]);
+                }
+            }
+            window.sort_by(|a, b| a.total_cmp(b));
+            // SciPy returns the lower-middle element for even-sized windows.
+            out[r * cols + c] = window[(window.len() - 1) / 2];
+        }
+    }
+    out
+}
+
+/// Separable Gaussian filter (`scipy.ndimage.gaussian_filter`, `truncate=4.0`,
+/// reflect mode).
+fn gaussian_filter(src: &[f64], rows: usize, cols: usize, sigma: f64) -> Vec<f64> {
+    if sigma <= 0.0 {
+        return src.to_vec();
+    }
+    let radius = (4.0 * sigma + 0.5) as isize;
+    let mut kernel = vec![0.0_f64; (2 * radius + 1) as usize];
+    let mut sum = 0.0;
+    for (j, w) in kernel.iter_mut().enumerate() {
+        let x = j as isize - radius;
+        let val = (-(x * x) as f64 / (2.0 * sigma * sigma)).exp();
+        *w = val;
+        sum += val;
+    }
+    for w in &mut kernel {
+        *w /= sum;
+    }
+
+    // Horizontal pass.
+    let mut tmp = vec![0.0_f64; rows * cols];
+    for r in 0..rows {
+        for c in 0..cols {
+            let mut acc = 0.0;
+            for (j, &w) in kernel.iter().enumerate() {
+                let dc = j as isize - radius;
+                let cc = reflect(c as isize + dc, cols);
+                acc += w * src[r * cols + cc];
+            }
+            tmp[r * cols + c] = acc;
+        }
+    }
+    // Vertical pass.
+    let mut out = vec![0.0_f64; rows * cols];
+    for r in 0..rows {
+        for c in 0..cols {
+            let mut acc = 0.0;
+            for (j, &w) in kernel.iter().enumerate() {
+                let dr = j as isize - radius;
+                let rr = reflect(r as isize + dr, rows);
+                acc += w * tmp[rr * cols + c];
+            }
+            out[r * cols + c] = acc;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mean_of_constant_is_constant() {
+        let src = vec![5.0; 9];
+        let out = mean_filter(&src, 3, 3, 3);
+        for v in out {
+            assert!((v - 5.0).abs() < 1e-9);
+        }
+    }
+
+    #[test]
+    fn median_removes_spike() {
+        // A single high spike in the center is replaced by the neighborhood median.
+        let mut src = vec![1.0; 9];
+        src[4] = 100.0;
+        let out = median_filter(&src, 3, 3, 3);
+        assert_eq!(out[4], 1.0);
+    }
+
+    #[test]
+    fn gaussian_preserves_constant() {
+        let src = vec![7.0; 25];
+        let out = gaussian_filter(&src, 5, 5, 1.0);
+        for v in out {
+            assert!((v - 7.0).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn reflect_indexing() {
+        assert_eq!(reflect(-1, 5), 0);
+        assert_eq!(reflect(-2, 5), 1);
+        assert_eq!(reflect(5, 5), 4);
+        assert_eq!(reflect(6, 5), 3);
+    }
+}

--- a/crates/geolibre-tools/src/extract_sinks.rs
+++ b/crates/geolibre-tools/src/extract_sinks.rs
@@ -1,0 +1,333 @@
+//! Sink (maximum depression extent) extraction, ported from `lidar`'s
+//! `filling.py` `ExtractSinks`.
+//!
+//! Pipeline: fill depressions (Wang & Liu), subtract the original DEM to get the
+//! fill depth, group the filled cells into components of more than `min_size`
+//! pixels, then emit the sink elevations, the labeled regions, the fill depth,
+//! the filled DEM, and a per-region attribute CSV.
+
+use std::collections::HashMap;
+
+use serde_json::{json, Map, Value};
+use wbcore::{
+    LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata, ToolParamSpec,
+    ToolRunResult,
+};
+use wbraster::DataType;
+
+use crate::common::{
+    band_to_vec, load_input_raster, parse_optional_output, raster_like_with_data, write_or_store_output,
+    write_text_output,
+};
+use crate::fill::fill_depressions_wang_and_liu;
+use crate::polygonize::{polygonize_to_geojson, PolygonizeParams};
+use crate::regions::{region_group, region_props, RegionProps};
+
+/// Arrays and attributes produced by sink extraction. All buffers are row-major
+/// of length `rows * cols`.
+pub struct SinkResult {
+    /// DEM elevation inside sinks, `0` elsewhere (no-data value `0`).
+    pub sink: Vec<f64>,
+    /// 1-based region id per cell, `0` background.
+    pub region: Vec<f64>,
+    /// Fill depth (`filled - dem`) inside sinks, `0` elsewhere.
+    pub depth: Vec<f64>,
+    /// Depression-filled DEM (no-data preserved).
+    pub filled: Vec<f64>,
+    /// Per-region attributes (ascending region id).
+    pub props: Vec<RegionProps>,
+}
+
+/// Core of `ExtractSinks`, independent of raster I/O so other tools (e.g.
+/// `DelineateMounts`) can reuse it.
+pub fn extract_sinks_core(
+    dem: &[f64],
+    rows: usize,
+    cols: usize,
+    nodata: f64,
+    min_size: u64,
+    flat_increment: f64,
+) -> SinkResult {
+    let filled = fill_depressions_wang_and_liu(dem, rows, cols, nodata, flat_increment);
+
+    // Fill depth; 0 outside depressions and at no-data cells.
+    let mut diff = vec![0.0_f64; rows * cols];
+    for i in 0..rows * cols {
+        if dem[i] != nodata && filled[i] != nodata {
+            let d = filled[i] - dem[i];
+            diff[i] = if d > 0.0 { d } else { 0.0 };
+        }
+    }
+
+    // Group filled cells into depression regions larger than min_size.
+    let (labels, count) = region_group(&diff, rows, cols, min_size, nodata);
+    let props = region_props(&labels, count, dem, rows, cols);
+
+    let mut sink = vec![0.0_f64; rows * cols];
+    let mut region = vec![0.0_f64; rows * cols];
+    let mut depth = vec![0.0_f64; rows * cols];
+    for i in 0..rows * cols {
+        if labels[i] != 0 && dem[i] != nodata {
+            sink[i] = dem[i];
+            region[i] = labels[i] as f64;
+            depth[i] = diff[i];
+        }
+    }
+
+    SinkResult {
+        sink,
+        region,
+        depth,
+        filled,
+        props,
+    }
+}
+
+/// Builds the per-region attribute CSV emitted by `ExtractSinks`.
+pub fn sink_csv(props: &[RegionProps], resolution: f64) -> String {
+    let mut csv = String::from(
+        "region_id,count,area,volume,avg_depth,max_depth,min_elev,max_elev,perimeter,\
+         major_axis,minor_axis,elongatedness,eccentricity,orientation,area_bbox_ratio\n",
+    );
+    let res2 = resolution * resolution;
+    for p in props {
+        let count = p.area as f64;
+        let size = count * res2;
+        let max_depth = p.max_intensity - p.min_intensity;
+        let mean_depth = (p.max_intensity * count - p.sum_intensity) / count;
+        let volume = mean_depth * count * res2;
+        let perimeter = p.perimeter * resolution;
+        let major_axis = p.major_axis_length * resolution;
+        let mut minor_axis = p.minor_axis_length * resolution;
+        if minor_axis == 0.0 {
+            minor_axis = resolution;
+        }
+        let elongatedness = major_axis / minor_axis;
+        // lidar divides by the literal 3.1415 (not PI); kept for output parity.
+        #[allow(clippy::approx_constant)]
+        let orientation = p.orientation / 3.1415 * 180.0;
+        csv.push_str(&format!(
+            "{},{},{:.2},{:.2},{:.2},{:.2},{:.2},{:.2},{:.2},{:.2},{:.2},{:.2},{:.2},{:.2},{:.2}\n",
+            p.label,
+            p.area,
+            size,
+            volume,
+            mean_depth,
+            max_depth,
+            p.min_intensity,
+            p.max_intensity,
+            perimeter,
+            major_axis,
+            minor_axis,
+            elongatedness,
+            p.eccentricity,
+            orientation,
+            p.extent,
+        ));
+    }
+    csv
+}
+
+/// Builds a per-region attribute table (keyed by region id) for joining onto
+/// polygonized features. Mirrors the columns of [`sink_csv`].
+#[allow(clippy::approx_constant)]
+pub fn region_props_map(props: &[RegionProps], resolution: f64) -> HashMap<i64, Map<String, Value>> {
+    let res2 = resolution * resolution;
+    let mut map = HashMap::new();
+    for p in props {
+        let count = p.area as f64;
+        let max_depth = p.max_intensity - p.min_intensity;
+        let mean_depth = (p.max_intensity * count - p.sum_intensity) / count;
+        let major_axis = p.major_axis_length * resolution;
+        let mut minor_axis = p.minor_axis_length * resolution;
+        if minor_axis == 0.0 {
+            minor_axis = resolution;
+        }
+        let mut attrs = Map::new();
+        attrs.insert("region_id".to_string(), json!(p.label));
+        attrs.insert("count".to_string(), json!(p.area));
+        attrs.insert("area".to_string(), json!(count * res2));
+        attrs.insert("volume".to_string(), json!(mean_depth * count * res2));
+        attrs.insert("avg_depth".to_string(), json!(mean_depth));
+        attrs.insert("max_depth".to_string(), json!(max_depth));
+        attrs.insert("min_elev".to_string(), json!(p.min_intensity));
+        attrs.insert("max_elev".to_string(), json!(p.max_intensity));
+        attrs.insert("perimeter".to_string(), json!(p.perimeter * resolution));
+        attrs.insert("major_axis".to_string(), json!(major_axis));
+        attrs.insert("minor_axis".to_string(), json!(minor_axis));
+        attrs.insert("elongatedness".to_string(), json!(major_axis / minor_axis));
+        attrs.insert("eccentricity".to_string(), json!(p.eccentricity));
+        attrs.insert("orientation".to_string(), json!(p.orientation / 3.1415 * 180.0));
+        attrs.insert("area_bbox_ratio".to_string(), json!(p.extent));
+        map.insert(p.label as i64, attrs);
+    }
+    map
+}
+
+/// Extracts sinks from a DEM (`lidar` `ExtractSinks`).
+pub struct ExtractSinksTool;
+
+impl Tool for ExtractSinksTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "extract_sinks",
+            display_name: "Extract Sinks",
+            summary: "Extract sinks (maximum depression extent) from a DEM (lidar filling.py).",
+            category: ToolCategory::Hydrology,
+            license_tier: LicenseTier::Open,
+            params: vec![
+                ToolParamSpec {
+                    name: "input",
+                    description: "Input DEM raster file path.",
+                    required: true,
+                },
+                ToolParamSpec {
+                    name: "output",
+                    description: "Optional sink raster path. If omitted, stored in memory.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "min_size",
+                    description: "Minimum number of pixels for a sink (kept if strictly greater; default 10).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "region_output",
+                    description: "Optional output path for the labeled-region raster.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "depth_output",
+                    description: "Optional output path for the fill-depth raster.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "filled_output",
+                    description: "Optional output path for the depression-filled DEM.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "csv_output",
+                    description: "Optional output path for the per-region attribute CSV.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "vector_output",
+                    description: "Optional output path for region polygons as GeoJSON (attributes joined).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "flat_increment",
+                    description: "Flat increment added during filling to enforce drainage (default 0).",
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        if args.get("input").and_then(Value::as_str).is_none() {
+            return Err(ToolError::Validation(
+                "missing required string parameter 'input'".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = args
+            .get("input")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::Validation("missing required parameter 'input'".to_string()))?;
+        let output = parse_optional_output(args, "output")?;
+        let region_output = parse_optional_output(args, "region_output")?;
+        let depth_output = parse_optional_output(args, "depth_output")?;
+        let filled_output = parse_optional_output(args, "filled_output")?;
+        let csv_output = parse_optional_output(args, "csv_output")?;
+        let vector_output = parse_optional_output(args, "vector_output")?;
+        let min_size = args.get("min_size").and_then(Value::as_u64).unwrap_or(10);
+        let flat_increment = args.get("flat_increment").and_then(Value::as_f64).unwrap_or(0.0);
+
+        let raster = load_input_raster(input)?;
+        let rows = raster.rows;
+        let cols = raster.cols;
+        let nodata = raster.nodata;
+        let resolution = raster.cell_size_x;
+        let dem = band_to_vec(&raster, 0);
+
+        ctx.progress.info("filling depressions");
+        let result = extract_sinks_core(&dem, rows, cols, nodata, min_size, flat_increment);
+        ctx.progress.progress(0.7);
+
+        let mut outputs = std::collections::BTreeMap::new();
+
+        let sink_raster = raster_like_with_data(&raster, result.sink, 0.0, raster.data_type)?;
+        let sink_path = write_or_store_output(sink_raster, output)?;
+        outputs.insert("output".to_string(), json!(sink_path));
+
+        if let Some(path) = vector_output {
+            let pmap = region_props_map(&result.props, resolution);
+            let geojson = polygonize_to_geojson(&PolygonizeParams {
+                labels: &result.region,
+                rows,
+                cols,
+                x_min: raster.x_min,
+                y_max: raster.y_max(),
+                cell_size_x: raster.cell_size_x,
+                cell_size_y: raster.cell_size_y,
+                epsg: raster.crs.epsg,
+                props_by_id: &pmap,
+            });
+            write_text_output(&geojson, path)?;
+            outputs.insert("vector".to_string(), json!(path));
+        }
+        if let Some(path) = region_output {
+            let r = raster_like_with_data(&raster, result.region, 0.0, DataType::I32)?;
+            outputs.insert("region".to_string(), json!(write_or_store_output(r, Some(path))?));
+        }
+        if let Some(path) = depth_output {
+            let r = raster_like_with_data(&raster, result.depth, 0.0, raster.data_type)?;
+            outputs.insert("depth".to_string(), json!(write_or_store_output(r, Some(path))?));
+        }
+        if let Some(path) = filled_output {
+            let r = raster_like_with_data(&raster, result.filled, nodata, raster.data_type)?;
+            outputs.insert("filled".to_string(), json!(write_or_store_output(r, Some(path))?));
+        }
+        if let Some(path) = csv_output {
+            write_text_output(&sink_csv(&result.props, resolution), path)?;
+            outputs.insert("csv".to_string(), json!(path));
+        }
+
+        outputs.insert("regions".to_string(), json!(result.props.len()));
+        ctx.progress.progress(1.0);
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_a_simple_sink() {
+        // 5x5 plateau at 10 with a 3x3 pit (value 1) in the middle.
+        let rows = 5;
+        let cols = 5;
+        let nodata = -9999.0;
+        let mut dem = vec![10.0; rows * cols];
+        for r in 1..4 {
+            for c in 1..4 {
+                dem[r * cols + c] = 1.0;
+            }
+        }
+        let result = extract_sinks_core(&dem, rows, cols, nodata, 1, 0.0);
+        // The 9-cell pit should be one region with sink elevations preserved.
+        assert_eq!(result.props.len(), 1);
+        assert_eq!(result.props[0].area, 9);
+        assert_eq!(result.sink[2 * cols + 2], 1.0);
+        assert_eq!(result.region[2 * cols + 2], 1.0);
+        // Filled center is raised to the rim.
+        assert_eq!(result.filled[2 * cols + 2], 10.0);
+        assert!(result.depth[2 * cols + 2] > 0.0);
+    }
+}

--- a/crates/geolibre-tools/src/fill.rs
+++ b/crates/geolibre-tools/src/fill.rs
@@ -1,0 +1,170 @@
+//! Wang & Liu priority-flood depression filling.
+//!
+//! Ported from the `fill_depressions_wang_and_liu` core in
+//! `whitebox-wasm`'s `wbtools_oss` so that `geolibre-tools` stays free of a
+//! `wbtools_oss` dependency (keeping it reusable for native/Python bindings and
+//! avoiding a dependency cycle). The algorithm seeds a min-heap from the grid
+//! edge and floods inward, raising each cell to at least its lowest already
+//! processed neighbor (plus an optional flat increment).
+
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, VecDeque};
+
+/// 8-connectivity offsets used by the flood.
+const DX: [isize; 8] = [1, 1, 1, 0, -1, -1, -1, 0];
+const DY: [isize; 8] = [-1, 0, 1, 1, 1, 0, -1, -1];
+
+#[inline]
+fn in_bounds(r: isize, c: isize, rows: usize, cols: usize) -> bool {
+    r >= 0 && c >= 0 && (r as usize) < rows && (c as usize) < cols
+}
+
+#[inline]
+fn idx(r: usize, c: usize, cols: usize) -> usize {
+    r * cols + c
+}
+
+/// A min-heap node ordered by ascending elevation (the `BinaryHeap` is a
+/// max-heap, so the `Ord` impl is reversed).
+struct MinNode {
+    elev: f64,
+    i: usize,
+}
+
+impl PartialEq for MinNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.elev == other.elev
+    }
+}
+impl Eq for MinNode {}
+impl PartialOrd for MinNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for MinNode {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Reversed so the heap pops the lowest elevation first.
+        other.elev.total_cmp(&self.elev)
+    }
+}
+
+/// Fills depressions in a row-major elevation grid using the Wang & Liu
+/// priority-flood. `small` is the flat increment added to enforce a monotone
+/// descent across flats (use `0.0` to disable). No-data cells are preserved.
+pub fn fill_depressions_wang_and_liu(
+    input: &[f64],
+    rows: usize,
+    cols: usize,
+    nodata: f64,
+    small: f64,
+) -> Vec<f64> {
+    let background = (i32::MIN + 1) as f64;
+    let mut out = vec![background; rows * cols];
+    let mut queue = VecDeque::<(isize, isize)>::new();
+
+    // Seed the flood from one ring outside every edge.
+    for r in 0..rows as isize {
+        queue.push_back((r, -1));
+        queue.push_back((r, cols as isize));
+    }
+    for c in 0..cols as isize {
+        queue.push_back((-1, c));
+        queue.push_back((rows as isize, c));
+    }
+
+    let mut heap = BinaryHeap::<MinNode>::new();
+    while let Some((r, c)) = queue.pop_front() {
+        for k in 0..8 {
+            let rn = r + DY[k];
+            let cn = c + DX[k];
+            if !in_bounds(rn, cn, rows, cols) {
+                continue;
+            }
+            let ni = idx(rn as usize, cn as usize, cols);
+            if out[ni] != background {
+                continue;
+            }
+            let zin = input[ni];
+            if zin == nodata {
+                out[ni] = nodata;
+                queue.push_back((rn, cn));
+            } else {
+                out[ni] = zin;
+                heap.push(MinNode { elev: zin, i: ni });
+            }
+        }
+    }
+
+    while let Some(cell) = heap.pop() {
+        let r = cell.i / cols;
+        let c = cell.i % cols;
+        let z = out[cell.i];
+        for k in 0..8 {
+            let rn = r as isize + DY[k];
+            let cn = c as isize + DX[k];
+            if !in_bounds(rn, cn, rows, cols) {
+                continue;
+            }
+            let ni = idx(rn as usize, cn as usize, cols);
+            if out[ni] != background {
+                continue;
+            }
+            let mut zn = input[ni];
+            if zn != nodata {
+                if zn < z + small {
+                    zn = z + small;
+                }
+                out[ni] = zn;
+                heap.push(MinNode { elev: zn, i: ni });
+            } else {
+                out[ni] = nodata;
+            }
+        }
+    }
+
+    for v in &mut out {
+        if *v == background {
+            *v = nodata;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fills_a_single_pit() {
+        // 3x3 bowl: a low center surrounded by a rim of 10s gets raised to 10.
+        let rows = 3;
+        let cols = 3;
+        let nodata = -9999.0;
+        let input = vec![10.0, 10.0, 10.0, 10.0, 1.0, 10.0, 10.0, 10.0, 10.0];
+        let out = fill_depressions_wang_and_liu(&input, rows, cols, nodata, 0.0);
+        assert_eq!(out[idx(1, 1, cols)], 10.0);
+        // Rim is unchanged.
+        assert_eq!(out[idx(0, 0, cols)], 10.0);
+    }
+
+    #[test]
+    fn preserves_nodata() {
+        let rows = 2;
+        let cols = 2;
+        let nodata = -9999.0;
+        let input = vec![5.0, nodata, 3.0, 4.0];
+        let out = fill_depressions_wang_and_liu(&input, rows, cols, nodata, 0.0);
+        assert_eq!(out[1], nodata);
+    }
+
+    #[test]
+    fn leaves_monotone_surface_unchanged() {
+        let rows = 1;
+        let cols = 4;
+        let nodata = -9999.0;
+        let input = vec![4.0, 3.0, 2.0, 1.0];
+        let out = fill_depressions_wang_and_liu(&input, rows, cols, nodata, 0.0);
+        assert_eq!(out, input);
+    }
+}

--- a/crates/geolibre-tools/src/lib.rs
+++ b/crates/geolibre-tools/src/lib.rs
@@ -7,7 +7,15 @@
 //! Add a new tool by creating a module with a `Tool` impl and pushing it in
 //! [`geolibre_tools`].
 
+mod common;
+mod delineate_depressions;
+mod delineate_mounts;
+mod dem_filter;
+mod extract_sinks;
+mod fill;
+mod polygonize;
 mod raster_normalize;
+mod regions;
 
 use wbcore::Tool;
 
@@ -24,7 +32,13 @@ use wbcore::Tool;
 /// }
 /// ```
 pub fn geolibre_tools() -> Vec<Box<dyn Tool>> {
-    vec![Box::new(raster_normalize::RasterNormalizeTool)]
+    vec![
+        Box::new(raster_normalize::RasterNormalizeTool),
+        Box::new(dem_filter::DemFilterTool),
+        Box::new(extract_sinks::ExtractSinksTool),
+        Box::new(delineate_depressions::DelineateDepressionsTool),
+        Box::new(delineate_mounts::DelineateMountsTool),
+    ]
 }
 
 #[cfg(test)]

--- a/crates/geolibre-tools/src/polygonize.rs
+++ b/crates/geolibre-tools/src/polygonize.rs
@@ -1,0 +1,402 @@
+//! Raster-to-vector polygonization, a pure-Rust port of the `gdal.Polygonize`
+//! step in `lidar` (`filling.py` / `slicing.py`).
+//!
+//! Each connected group of equal-valued, nonzero cells (4-connectivity, as GDAL
+//! uses by default) becomes one polygon feature. Cell-edge boundaries are traced
+//! into rings, inner rings are emitted as holes, and the per-region attributes
+//! are joined onto each feature. Output is a GeoJSON `FeatureCollection` in the
+//! raster's own CRS, which is what GeoLibre / MapLibre consume directly.
+
+use std::collections::HashMap;
+
+use serde_json::{json, Map, Value};
+
+/// Geometry/attribute inputs for one polygonization pass.
+pub struct PolygonizeParams<'a> {
+    pub labels: &'a [f64],
+    pub rows: usize,
+    pub cols: usize,
+    pub x_min: f64,
+    pub y_max: f64,
+    pub cell_size_x: f64,
+    pub cell_size_y: f64,
+    pub epsg: Option<u32>,
+    /// Attribute table keyed by integer id; merged into each feature's
+    /// properties (alongside the always-present `id`).
+    pub props_by_id: &'a HashMap<i64, Map<String, Value>>,
+}
+
+/// A vertex on the cell-corner grid: `(col, row)`, with `0..=cols` / `0..=rows`.
+type Vertex = (i64, i64);
+
+/// Polygonizes a label raster into a GeoJSON `FeatureCollection` string.
+pub fn polygonize_to_geojson(p: &PolygonizeParams) -> String {
+    let groups = connected_groups(p.labels, p.rows, p.cols);
+
+    let mut features: Vec<Value> = Vec::new();
+    for group in groups {
+        let rings = trace_rings(&group.cells, p.cols);
+        if rings.is_empty() {
+            continue;
+        }
+        let geometry = rings_to_geometry(rings, p);
+
+        let mut props = p
+            .props_by_id
+            .get(&group.id)
+            .cloned()
+            .unwrap_or_default();
+        props.entry("id".to_string()).or_insert(json!(group.id));
+
+        features.push(json!({
+            "type": "Feature",
+            "properties": Value::Object(props),
+            "geometry": geometry,
+        }));
+    }
+
+    let mut fc = Map::new();
+    fc.insert("type".to_string(), json!("FeatureCollection"));
+    if let Some(epsg) = p.epsg {
+        fc.insert(
+            "crs".to_string(),
+            json!({"type": "name", "properties": {"name": format!("EPSG:{epsg}")}}),
+        );
+    }
+    fc.insert("features".to_string(), Value::Array(features));
+    Value::Object(fc).to_string()
+}
+
+/// A connected component of equal-valued, nonzero cells.
+struct Group {
+    id: i64,
+    cells: Vec<usize>,
+}
+
+/// Flood-fills the raster into 4-connected groups of equal nonzero value
+/// (matching GDAL's per-value connected polygons).
+fn connected_groups(labels: &[f64], rows: usize, cols: usize) -> Vec<Group> {
+    let mut visited = vec![false; rows * cols];
+    let mut groups = Vec::new();
+    let mut stack: Vec<usize> = Vec::new();
+
+    for start in 0..rows * cols {
+        if visited[start] || labels[start] == 0.0 {
+            continue;
+        }
+        let id = labels[start] as i64;
+        let mut cells = Vec::new();
+        stack.push(start);
+        visited[start] = true;
+        while let Some(i) = stack.pop() {
+            cells.push(i);
+            let r = i / cols;
+            let c = i % cols;
+            for (dr, dc) in [(-1isize, 0isize), (1, 0), (0, -1), (0, 1)] {
+                let nr = r as isize + dr;
+                let nc = c as isize + dc;
+                if nr < 0 || nc < 0 || nr >= rows as isize || nc >= cols as isize {
+                    continue;
+                }
+                let ni = nr as usize * cols + nc as usize;
+                if !visited[ni] && labels[ni] as i64 == id && labels[ni] != 0.0 {
+                    visited[ni] = true;
+                    stack.push(ni);
+                }
+            }
+        }
+        groups.push(Group { id, cells });
+    }
+    groups
+}
+
+/// Traces the boundary of a cell group into one or more closed rings of grid
+/// vertices. Interior cell edges cancel; only the outer/inner boundaries remain.
+fn trace_rings(cells: &[usize], cols: usize) -> Vec<Vec<Vertex>> {
+    let cellset: std::collections::HashSet<usize> = cells.iter().copied().collect();
+    let in_group = |r: i64, c: i64| -> bool {
+        if r < 0 || c < 0 {
+            return false;
+        }
+        cellset.contains(&(r as usize * cols + c as usize))
+    };
+
+    // Directed boundary edges (interior on a consistent side); shared edges
+    // between two in-group cells appear in both directions and are omitted.
+    let mut outgoing: HashMap<Vertex, Vec<Vertex>> = HashMap::new();
+    let mut push_edge = |a: Vertex, b: Vertex| outgoing.entry(a).or_default().push(b);
+
+    for &i in cells {
+        let r = (i / cols) as i64;
+        let c = (i % cols) as i64;
+        let a = (c, r);
+        let b = (c + 1, r);
+        let d = (c, r + 1);
+        let e = (c + 1, r + 1);
+        if !in_group(r - 1, c) {
+            push_edge(a, b); // top
+        }
+        if !in_group(r, c + 1) {
+            push_edge(b, e); // right
+        }
+        if !in_group(r + 1, c) {
+            push_edge(e, d); // bottom
+        }
+        if !in_group(r, c - 1) {
+            push_edge(d, a); // left
+        }
+    }
+
+    // Walk directed edges into closed rings.
+    let mut rings = Vec::new();
+    let mut vertices: Vec<Vertex> = outgoing.keys().copied().collect();
+    vertices.sort();
+    for start in vertices {
+        while outgoing.get(&start).map(|v| !v.is_empty()).unwrap_or(false) {
+            let mut ring = vec![start];
+            let mut cur = start;
+            let mut prev_dir: Option<(i64, i64)> = None;
+            loop {
+                let next = {
+                    let outs = outgoing.get_mut(&cur).expect("vertex has edges");
+                    let idx = choose_next(outs, cur, prev_dir);
+                    outs.swap_remove(idx)
+                };
+                prev_dir = Some((next.0 - cur.0, next.1 - cur.1));
+                cur = next;
+                if cur == start {
+                    break;
+                }
+                ring.push(cur);
+            }
+            if ring.len() >= 3 {
+                rings.push(simplify_collinear(ring));
+            }
+        }
+    }
+    rings
+}
+
+/// Picks the next edge when walking a ring. At a simple (degree-2) vertex there
+/// is one choice; at a checkerboard pinch we prefer the left-most turn so the
+/// two loops separate cleanly.
+fn choose_next(outs: &[Vertex], cur: Vertex, prev_dir: Option<(i64, i64)>) -> usize {
+    if outs.len() == 1 || prev_dir.is_none() {
+        return 0;
+    }
+    let (dx, dy) = prev_dir.unwrap();
+    let mut best = 0;
+    let mut best_score = i64::MAX;
+    for (k, &target) in outs.iter().enumerate() {
+        // Edges are emitted so the region's interior is on the right of each
+        // directed edge. At a checkerboard pinch (a degree-4 vertex), taking the
+        // most-clockwise turn (minimum cross product) hugs the interior and
+        // splits the boundary into two non-crossing loops.
+        let (ex, ey) = (target.0 - cur.0, target.1 - cur.1);
+        let cross = dx * ey - dy * ex;
+        if cross < best_score {
+            best_score = cross;
+            best = k;
+        }
+    }
+    best
+}
+
+/// Removes vertices that are collinear with their neighbors (rings are
+/// rectilinear, so this merges runs along the same axis).
+fn simplify_collinear(ring: Vec<Vertex>) -> Vec<Vertex> {
+    let n = ring.len();
+    if n < 3 {
+        return ring;
+    }
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        let prev = ring[(i + n - 1) % n];
+        let cur = ring[i];
+        let next = ring[(i + 1) % n];
+        let d1 = (cur.0 - prev.0, cur.1 - prev.1);
+        let d2 = (next.0 - cur.0, next.1 - cur.1);
+        // Keep the vertex only if the direction changes (cross product != 0).
+        if d1.0 * d2.1 - d1.1 * d2.0 != 0 {
+            out.push(cur);
+        }
+    }
+    out
+}
+
+/// Converts traced rings to a GeoJSON `Polygon`, classifying the largest ring as
+/// the exterior and the rest as holes, with RFC 7946 winding (exterior CCW,
+/// holes CW).
+fn rings_to_geometry(rings: Vec<Vec<Vertex>>, p: &PolygonizeParams) -> Value {
+    let to_world = |v: Vertex| -> [f64; 2] {
+        [
+            p.x_min + v.0 as f64 * p.cell_size_x,
+            p.y_max - v.1 as f64 * p.cell_size_y,
+        ]
+    };
+
+    // World-space rings with their signed area.
+    let mut world: Vec<(Vec<[f64; 2]>, f64)> = rings
+        .into_iter()
+        .map(|ring| {
+            let coords: Vec<[f64; 2]> = ring.iter().map(|&v| to_world(v)).collect();
+            let area = signed_area(&coords);
+            (coords, area)
+        })
+        .collect();
+
+    // Exterior = largest absolute area.
+    let exterior_idx = world
+        .iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.1.abs().total_cmp(&b.1.abs()))
+        .map(|(i, _)| i)
+        .unwrap_or(0);
+
+    let mut coordinates: Vec<Value> = Vec::with_capacity(world.len());
+    // Emit exterior first (CCW), then holes (CW).
+    let exterior = std::mem::take(&mut world[exterior_idx]);
+    coordinates.push(close_ring(orient(exterior.0, exterior.1, true)));
+    for (i, (coords, area)) in world.into_iter().enumerate() {
+        if i == exterior_idx || coords.is_empty() {
+            continue;
+        }
+        coordinates.push(close_ring(orient(coords, area, false)));
+    }
+
+    json!({"type": "Polygon", "coordinates": coordinates})
+}
+
+/// Shoelace signed area (positive = counterclockwise).
+fn signed_area(ring: &[[f64; 2]]) -> f64 {
+    let n = ring.len();
+    let mut a = 0.0;
+    for i in 0..n {
+        let p1 = ring[i];
+        let p2 = ring[(i + 1) % n];
+        a += p1[0] * p2[1] - p2[0] * p1[1];
+    }
+    a / 2.0
+}
+
+/// Orients a ring CCW (`want_ccw = true`) or CW, given its current signed area.
+fn orient(mut ring: Vec<[f64; 2]>, area: f64, want_ccw: bool) -> Vec<[f64; 2]> {
+    let is_ccw = area > 0.0;
+    if is_ccw != want_ccw {
+        ring.reverse();
+    }
+    ring
+}
+
+/// Closes a ring (repeats the first point) and converts to JSON.
+fn close_ring(ring: Vec<[f64; 2]>) -> Value {
+    let mut pts: Vec<Value> = ring.iter().map(|p| json!([p[0], p[1]])).collect();
+    if let Some(first) = ring.first() {
+        pts.push(json!([first[0], first[1]]));
+    }
+    Value::Array(pts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(s: &str) -> Value {
+        serde_json::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn square_block_becomes_one_polygon() {
+        // 4x4 grid, a 2x2 block of id 1 in the top-left.
+        let rows = 4;
+        let cols = 4;
+        let mut labels = vec![0.0; rows * cols];
+        for (r, c) in [(0, 0), (0, 1), (1, 0), (1, 1)] {
+            labels[r * cols + c] = 1.0;
+        }
+        let props: HashMap<i64, Map<String, Value>> = HashMap::new();
+        let geojson = polygonize_to_geojson(&PolygonizeParams {
+            labels: &labels,
+            rows,
+            cols,
+            x_min: 0.0,
+            y_max: 4.0,
+            cell_size_x: 1.0,
+            cell_size_y: 1.0,
+            epsg: Some(4326),
+            props_by_id: &props,
+        });
+        let v = parse(&geojson);
+        let features = v["features"].as_array().unwrap();
+        assert_eq!(features.len(), 1);
+        let coords = features[0]["geometry"]["coordinates"].as_array().unwrap();
+        // One exterior ring, no holes.
+        assert_eq!(coords.len(), 1);
+        let ring = coords[0].as_array().unwrap();
+        // 4 corners after collinear merge, plus the closing point.
+        assert_eq!(ring.len(), 5);
+        assert_eq!(features[0]["properties"]["id"], json!(1));
+    }
+
+    #[test]
+    fn donut_has_a_hole() {
+        // 5x5 ring of id 1 around a hole at the center.
+        let rows = 5;
+        let cols = 5;
+        let mut labels = vec![0.0; rows * cols];
+        for r in 1..4 {
+            for c in 1..4 {
+                labels[r * cols + c] = 1.0;
+            }
+        }
+        labels[2 * cols + 2] = 0.0; // punch the hole
+        let props: HashMap<i64, Map<String, Value>> = HashMap::new();
+        let geojson = polygonize_to_geojson(&PolygonizeParams {
+            labels: &labels,
+            rows,
+            cols,
+            x_min: 0.0,
+            y_max: 5.0,
+            cell_size_x: 1.0,
+            cell_size_y: 1.0,
+            epsg: None,
+            props_by_id: &props,
+        });
+        let v = parse(&geojson);
+        let coords = v["features"][0]["geometry"]["coordinates"]
+            .as_array()
+            .unwrap();
+        // Exterior + one hole.
+        assert_eq!(coords.len(), 2);
+    }
+
+    #[test]
+    fn winding_is_rfc7946() {
+        let rows = 3;
+        let cols = 3;
+        let mut labels = vec![0.0; rows * cols];
+        labels[0] = 1.0;
+        let props: HashMap<i64, Map<String, Value>> = HashMap::new();
+        let geojson = polygonize_to_geojson(&PolygonizeParams {
+            labels: &labels,
+            rows,
+            cols,
+            x_min: 0.0,
+            y_max: 3.0,
+            cell_size_x: 1.0,
+            cell_size_y: 1.0,
+            epsg: None,
+            props_by_id: &props,
+        });
+        let v = parse(&geojson);
+        let ring = v["features"][0]["geometry"]["coordinates"][0]
+            .as_array()
+            .unwrap();
+        let pts: Vec<[f64; 2]> = ring
+            .iter()
+            .map(|p| [p[0].as_f64().unwrap(), p[1].as_f64().unwrap()])
+            .collect();
+        // Exterior ring must be counterclockwise (positive signed area).
+        assert!(signed_area(&pts[..pts.len() - 1]) > 0.0);
+    }
+}

--- a/crates/geolibre-tools/src/regions.rs
+++ b/crates/geolibre-tools/src/regions.rs
@@ -1,0 +1,388 @@
+//! Connected-component labeling and region properties, ported from the parts of
+//! `scipy.ndimage` and `skimage.measure` used by the `lidar` Python package.
+//!
+//! Two pieces are reproduced faithfully enough to match the Python outputs:
+//!
+//! * [`region_group`] mirrors `lidar`'s `regionGroup`: label nonzero cells with
+//!   4-connectivity (`scipy.ndimage.label`'s default cross structuring element),
+//!   drop components with `<= min_size` pixels, then relabel.
+//! * [`region_props`] mirrors the `skimage.measure.regionprops` attributes the
+//!   package consumes: area, bounding box, first coordinate, intensity
+//!   statistics, and the inertia-tensor shape descriptors (major/minor axis,
+//!   eccentricity, orientation) plus `skimage`'s 4-connectivity perimeter.
+
+/// 4-connectivity offsets (row, col): up, down, left, right.
+const NEIGHBORS_4: [(isize, isize); 4] = [(-1, 0), (1, 0), (0, -1), (0, 1)];
+
+/// Labels connected components of a boolean mask using 4-connectivity.
+///
+/// Returns `(labels, count)` where `labels[r*cols + c]` is the 1-based component
+/// id (0 = background) and `count` is the number of components. This matches
+/// `scipy.ndimage.label` with its default (cross) structuring element.
+pub fn label_4(mask: &[bool], rows: usize, cols: usize) -> (Vec<u32>, usize) {
+    let mut labels = vec![0_u32; rows * cols];
+    let mut next: u32 = 0;
+    let mut stack: Vec<(usize, usize)> = Vec::new();
+
+    for start_r in 0..rows {
+        for start_c in 0..cols {
+            let start = start_r * cols + start_c;
+            if !mask[start] || labels[start] != 0 {
+                continue;
+            }
+            next += 1;
+            labels[start] = next;
+            stack.push((start_r, start_c));
+            while let Some((r, c)) = stack.pop() {
+                for (dr, dc) in NEIGHBORS_4 {
+                    let nr = r as isize + dr;
+                    let nc = c as isize + dc;
+                    if nr < 0 || nc < 0 || nr >= rows as isize || nc >= cols as isize {
+                        continue;
+                    }
+                    let ni = nr as usize * cols + nc as usize;
+                    if mask[ni] && labels[ni] == 0 {
+                        labels[ni] = next;
+                        stack.push((nr as usize, nc as usize));
+                    }
+                }
+            }
+        }
+    }
+    (labels, next as usize)
+}
+
+/// Ports `lidar`'s `regionGroup`: treat every nonzero cell as foreground, label
+/// with 4-connectivity, discard components with `<= min_size` pixels (strictly
+/// greater is kept, matching `sizes > min_size`), then relabel the survivors.
+///
+/// `values` is the working buffer; cells equal to `nodata` are treated as
+/// background (0). Returns `(labels, count)` of the relabeled image.
+pub fn region_group(values: &[f64], rows: usize, cols: usize, min_size: u64, nodata: f64) -> (Vec<u32>, usize) {
+    let mask: Vec<bool> = values
+        .iter()
+        .map(|&v| v != 0.0 && v != nodata)
+        .collect();
+    let (labels, count) = label_4(&mask, rows, cols);
+
+    // Count pixels per component.
+    let mut sizes = vec![0_u64; count + 1];
+    for &l in &labels {
+        sizes[l as usize] += 1;
+    }
+
+    // Keep components strictly larger than min_size; background (0) is dropped.
+    let keep: Vec<bool> = sizes.iter().enumerate().map(|(i, &s)| i != 0 && s > min_size).collect();
+    let cleaned: Vec<bool> = labels.iter().map(|&l| keep[l as usize]).collect();
+    label_4(&cleaned, rows, cols)
+}
+
+/// Region attributes mirroring the `skimage.measure.regionprops` fields used by
+/// `lidar`. Geometry is in pixel units; callers scale by spatial resolution.
+#[derive(Debug, Clone)]
+pub struct RegionProps {
+    /// 1-based component id (the `label`).
+    pub label: u32,
+    /// Pixel count (`area`).
+    pub area: u64,
+    /// Bounding box `(min_row, min_col, max_row, max_col)`, max exclusive.
+    pub bbox: (usize, usize, usize, usize),
+    /// First pixel in row-major order `(row, col)` (`coords[0]`).
+    pub first_coord: (usize, usize),
+    /// Minimum intensity over the region.
+    pub min_intensity: f64,
+    /// Maximum intensity over the region.
+    pub max_intensity: f64,
+    /// Sum of intensity over the region (`intensity_image` sums to this).
+    pub sum_intensity: f64,
+    /// Major axis length in pixels (`4 * sqrt(l1)` from the inertia tensor).
+    pub major_axis_length: f64,
+    /// Minor axis length in pixels (`4 * sqrt(l2)`).
+    pub minor_axis_length: f64,
+    /// Eccentricity, `sqrt(1 - l2/l1)`.
+    pub eccentricity: f64,
+    /// Orientation in radians (`skimage` convention).
+    pub orientation: f64,
+    /// Perimeter in pixels (`skimage` 4-connectivity weighting).
+    pub perimeter: f64,
+    /// Filled fraction of the bounding box (`extent` = area / bbox area).
+    pub extent: f64,
+}
+
+/// Computes [`RegionProps`] for every labeled component (1..=count).
+///
+/// `labels` and `intensity` are row-major buffers of length `rows*cols`.
+/// Background (`label == 0`) is ignored. Results are ordered by ascending label,
+/// matching `skimage.measure.regionprops`.
+pub fn region_props(
+    labels: &[u32],
+    count: usize,
+    intensity: &[f64],
+    rows: usize,
+    cols: usize,
+) -> Vec<RegionProps> {
+    if count == 0 {
+        return Vec::new();
+    }
+
+    // Per-label accumulators.
+    let mut area = vec![0_u64; count + 1];
+    let mut min_int = vec![f64::INFINITY; count + 1];
+    let mut max_int = vec![f64::NEG_INFINITY; count + 1];
+    let mut sum_int = vec![0.0_f64; count + 1];
+    let mut min_row = vec![usize::MAX; count + 1];
+    let mut min_col = vec![usize::MAX; count + 1];
+    let mut max_row = vec![0_usize; count + 1];
+    let mut max_col = vec![0_usize; count + 1];
+    let mut first = vec![None::<(usize, usize)>; count + 1];
+    // Moment sums for centroid and central moments.
+    let mut sum_r = vec![0.0_f64; count + 1];
+    let mut sum_c = vec![0.0_f64; count + 1];
+
+    for row in 0..rows {
+        for col in 0..cols {
+            let l = labels[row * cols + col] as usize;
+            if l == 0 {
+                continue;
+            }
+            area[l] += 1;
+            let v = intensity[row * cols + col];
+            if v < min_int[l] {
+                min_int[l] = v;
+            }
+            if v > max_int[l] {
+                max_int[l] = v;
+            }
+            sum_int[l] += v;
+            if row < min_row[l] {
+                min_row[l] = row;
+            }
+            if col < min_col[l] {
+                min_col[l] = col;
+            }
+            if row + 1 > max_row[l] {
+                max_row[l] = row + 1;
+            }
+            if col + 1 > max_col[l] {
+                max_col[l] = col + 1;
+            }
+            if first[l].is_none() {
+                first[l] = Some((row, col)); // row-major scan => coords[0]
+            }
+            sum_r[l] += row as f64;
+            sum_c[l] += col as f64;
+        }
+    }
+
+    let mut out = Vec::with_capacity(count);
+    for l in 1..=count {
+        if area[l] == 0 {
+            continue;
+        }
+        let n = area[l] as f64;
+        let cr = sum_r[l] / n;
+        let cc = sum_c[l] / n;
+        let bbox = (min_row[l], min_col[l], max_row[l], max_col[l]);
+
+        // Second central moments over the binary region (skimage inertia tensor).
+        let (mu20, mu02, mu11) = central_moments(labels, l as u32, cr, cc, bbox, cols);
+        let a = mu20 / n; // inertia_tensor[0,0]
+        let c = mu02 / n; // inertia_tensor[1,1]
+        let b = -mu11 / n; // inertia_tensor[0,1] = inertia_tensor[1,0]
+
+        let common = (4.0 * b * b + (a - c) * (a - c)).max(0.0).sqrt();
+        let l1 = (a + c) / 2.0 + common / 2.0;
+        let l2 = ((a + c) / 2.0 - common / 2.0).max(0.0);
+        let major = 4.0 * l1.max(0.0).sqrt();
+        let minor = 4.0 * l2.sqrt();
+        let eccentricity = if l1 > 0.0 {
+            (1.0 - l2 / l1).max(0.0).sqrt()
+        } else {
+            0.0
+        };
+        let orientation = if a - c == 0.0 {
+            if b < 0.0 {
+                -std::f64::consts::FRAC_PI_4
+            } else {
+                std::f64::consts::FRAC_PI_4
+            }
+        } else {
+            0.5 * (-2.0 * b).atan2(c - a)
+        };
+
+        let bbox_area = ((bbox.2 - bbox.0) * (bbox.3 - bbox.1)) as f64;
+        let extent = if bbox_area > 0.0 { n / bbox_area } else { 0.0 };
+        let perimeter = perimeter_4(labels, l as u32, bbox, cols);
+
+        out.push(RegionProps {
+            label: l as u32,
+            area: area[l],
+            bbox,
+            first_coord: first[l].unwrap(),
+            min_intensity: min_int[l],
+            max_intensity: max_int[l],
+            sum_intensity: sum_int[l],
+            major_axis_length: major,
+            minor_axis_length: minor,
+            eccentricity,
+            orientation,
+            perimeter,
+            extent,
+        });
+    }
+    out
+}
+
+/// Second-order central moments `(mu20, mu02, mu11)` of a labeled region's
+/// binary mask, taken about the centroid `(cr, cc)`.
+fn central_moments(
+    labels: &[u32],
+    label: u32,
+    cr: f64,
+    cc: f64,
+    bbox: (usize, usize, usize, usize),
+    cols: usize,
+) -> (f64, f64, f64) {
+    let (min_row, min_col, max_row, max_col) = bbox;
+    let mut mu20 = 0.0;
+    let mut mu02 = 0.0;
+    let mut mu11 = 0.0;
+    for row in min_row..max_row {
+        for col in min_col..max_col {
+            if labels[row * cols + col] != label {
+                continue;
+            }
+            let dr = row as f64 - cr;
+            let dc = col as f64 - cc;
+            mu20 += dr * dr;
+            mu02 += dc * dc;
+            mu11 += dr * dc;
+        }
+    }
+    (mu20, mu02, mu11)
+}
+
+/// `skimage.measure.perimeter` with 4-connectivity, evaluated over a region's
+/// bounding box.
+///
+/// The boundary is `mask - erosion(mask)` (border pixels), and each border pixel
+/// is weighted by a kernel-coded count of its orthogonal/diagonal border
+/// neighbors. Only border pixels (kernel center = 1) carry nonzero weight, so we
+/// score them directly instead of materializing the full convolution.
+fn perimeter_4(labels: &[u32], label: u32, bbox: (usize, usize, usize, usize), cols: usize) -> f64 {
+    let (min_row, min_col, max_row, max_col) = bbox;
+    let in_region = |r: isize, c: isize| -> bool {
+        if r < 0 || c < 0 {
+            return false;
+        }
+        let (r, c) = (r as usize, c as usize);
+        r < (labels.len() / cols) && c < cols && labels[r * cols + c] == label
+    };
+
+    // A border pixel is in the region but has at least one 4-neighbor outside
+    // it (binary_erosion with a cross structuring element and border_value=0).
+    let is_border = |r: isize, c: isize| -> bool {
+        if !in_region(r, c) {
+            return false;
+        }
+        for (dr, dc) in NEIGHBORS_4 {
+            if !in_region(r + dr, c + dc) {
+                return true;
+            }
+        }
+        false
+    };
+
+    let sqrt2 = std::f64::consts::SQRT_2;
+    let mut total = 0.0;
+    for row in min_row..max_row {
+        for col in min_col..max_col {
+            let r = row as isize;
+            let c = col as isize;
+            if !is_border(r, c) {
+                continue;
+            }
+            // Count orthogonal and diagonal border neighbors.
+            let mut orth = 0;
+            for (dr, dc) in NEIGHBORS_4 {
+                if is_border(r + dr, c + dc) {
+                    orth += 1;
+                }
+            }
+            let mut diag = 0;
+            for (dr, dc) in [(-1, -1), (-1, 1), (1, -1), (1, 1)] {
+                if is_border(r + dr, c + dc) {
+                    diag += 1;
+                }
+            }
+            // Convolution code = 1 (center) + 2*orth + 10*diag, mapped to the
+            // skimage perimeter weights.
+            let code = 1 + 2 * orth + 10 * diag;
+            total += match code {
+                5 | 7 | 15 | 17 | 25 | 27 => 1.0,
+                21 | 33 => sqrt2,
+                13 | 23 => (1.0 + sqrt2) / 2.0,
+                _ => 0.0,
+            };
+        }
+    }
+    total
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn labels_two_separate_blocks() {
+        // 4x4 with two 2x2 blocks in opposite corners.
+        let rows = 4;
+        let cols = 4;
+        let mut mask = vec![false; rows * cols];
+        for (r, c) in [(0, 0), (0, 1), (1, 0), (1, 1), (2, 2), (2, 3), (3, 2), (3, 3)] {
+            mask[r * cols + c] = true;
+        }
+        let (labels, count) = label_4(&mask, rows, cols);
+        assert_eq!(count, 2);
+        assert_eq!(labels[0], 1);
+        assert_eq!(labels[2 * cols + 2], 2);
+    }
+
+    #[test]
+    fn region_group_drops_small_components() {
+        // One large (>min_size) component and one single-pixel component.
+        let rows = 3;
+        let cols = 4;
+        let mut v = vec![0.0; rows * cols];
+        for (r, c) in [(0, 0), (0, 1), (1, 0), (1, 1)] {
+            v[r * cols + c] = 5.0;
+        }
+        v[2 * cols + 3] = 9.0; // lone pixel
+        let (labels, count) = region_group(&v, rows, cols, 1, 0.0);
+        assert_eq!(count, 1); // 4-pixel block survives min_size=1, lone pixel dropped
+        assert_eq!(labels[2 * cols + 3], 0);
+        assert_eq!(labels[0], 1);
+    }
+
+    #[test]
+    fn props_area_bbox_and_intensity() {
+        let rows = 3;
+        let cols = 3;
+        let mut labels = vec![0_u32; rows * cols];
+        // A 2x2 block in the top-left.
+        for (r, c) in [(0, 0), (0, 1), (1, 0), (1, 1)] {
+            labels[r * cols + c] = 1;
+        }
+        let intensity = vec![1.0, 2.0, 0.0, 3.0, 4.0, 0.0, 0.0, 0.0, 0.0];
+        let props = region_props(&labels, 1, &intensity, rows, cols);
+        assert_eq!(props.len(), 1);
+        let p = &props[0];
+        assert_eq!(p.area, 4);
+        assert_eq!(p.bbox, (0, 0, 2, 2));
+        assert_eq!(p.first_coord, (0, 0));
+        assert_eq!(p.min_intensity, 1.0);
+        assert_eq!(p.max_intensity, 4.0);
+        assert_eq!(p.sum_intensity, 10.0);
+        assert_eq!(p.extent, 1.0);
+    }
+}


### PR DESCRIPTION
## Summary

Ports the algorithms from [`opengeos/lidar`](https://github.com/opengeos/lidar) into the `geolibre-tools` crate as `wbcore::Tool` implementations. They have no GDAL / RichDEM / SciPy / scikit-image dependency, so they compile to `wasm32-wasip1` and run in the browser through the same WASI runner interface as the whitebox tools.

### New tools
| Tool id | Source | What it does |
|---|---|---|
| `dem_filter` | `filtering.py` | Mean / median / Gaussian DEM smoothing |
| `extract_sinks` | `filling.py` | Wang & Liu fill, group sinks > `min_size`; sink/region/depth/filled rasters + CSV + GeoJSON |
| `delineate_depressions` | `slicing.py` | Level-set slicing into a nested-depression hierarchy; id/level rasters + CSV + GeoJSON |
| `delineate_mounts` | `mounts.py` | Flip the DEM, then run the sink + depression pipeline |

### Supporting modules
- `regions` — `scipy.ndimage.label` (4-connectivity) + `skimage.regionprops` (inertia-tensor major/minor axis, eccentricity, orientation, 4-connectivity perimeter)
- `fill` — Wang & Liu priority-flood, ported from whitebox so the crate stays free of a `wbtools_oss` dependency
- `polygonize` — raster-to-GeoJSON (connected components, holes, RFC 7946 winding) with the attribute table joined onto each feature, replacing `gdal.Polygonize` + the GeoPackage join

### Notes on fidelity
- Depression fill defaults to `flat_increment=0` (configurable).
- The `orientation / 3.1415` literal is preserved from the Python for output parity.
- Two genuine edge-case bugs in the Python (`FlipDEM` no-data handling; the 1-pixel-wide depression branch) are replaced with sensible behavior, documented in comments.

## Testing
- 19 unit tests pass; `cargo clippy` clean.
- `cargo build -p geolibre-cli --release --target wasm32-wasip1` succeeds.
- End-to-end on the lidar sample `dem.tif`: `extract_sinks` -> 2 sinks; `delineate_depressions` -> 16 nested depressions (level-6 hierarchy); `delineate_mounts` -> 14 mounts.
- GeoJSON output validated with shapely 2.1.2: 0 invalid geometries across 151 depression polygons + 2 region polygons, area conserved.