### PR TITLE
Release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-tools"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde_json",
  "wbcore",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT OR Apache-2.0",
   "repository": {


### PR DESCRIPTION
Bump `geolibre-wasm` (npm) and the `geolibre-cli` / `geolibre-tools` / `geolibre-wasm` crates to **0.3.0**.

## Highlights since v0.2.0
- New lidar DEM depression/mount tool suite, ported to pure-Rust WASM (#2):
  - `dem_filter` (mean/median/Gaussian)
  - `extract_sinks` (Wang & Liu fill + sink grouping)
  - `delineate_depressions` (level-set nested-depression hierarchy)
  - `delineate_mounts` (flip + sink + delineate)
  - raster-to-GeoJSON polygonization with attributes joined

Minor (feature-additive, no breaking changes).

Merging this and pushing the `v0.3.0` tag triggers `release.yml` to build the WASM artifacts and publish `geolibre-wasm` to npm.