### PR TITLE
chore: relicense under MIT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /target
 node_modules
+# Local-only drafts and notes (e.g. LinkedIn announcements)
+/private/
 # Build artifacts staged into npm/ by build.sh (regenerated on every build)
 npm/geolibre-cli.wasm
 npm/geolibre_wasm.js

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-license = "MIT OR Apache-2.0"
+license = "MIT"
 repository = "https://github.com/opengeos/geolibre-rust"
 
 # Size-optimized WASM build. Mirrors opengeos/whitebox-wasm so the resulting

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Qiusheng Wu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -191,4 +191,4 @@ without the Python sidecar.
 
 ## License
 
-MIT OR Apache-2.0
+MIT. See [LICENSE](LICENSE).

--- a/npm/README.md
+++ b/npm/README.md
@@ -90,4 +90,4 @@ are GeoJSON.
 
 ## License
 
-MIT OR Apache-2.0
+MIT

--- a/npm/package.json
+++ b/npm/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.3.0",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
-  "license": "MIT OR Apache-2.0",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/opengeos/geolibre-rust"


### PR DESCRIPTION
## Summary
- Change the project license from "MIT OR Apache-2.0" to MIT across the Cargo workspace, the npm package, and both READMEs.
- Add the root MIT LICENSE file and ignore the local-only private/ drafts directory.

## Test plan
- [ ] Confirm `license = "MIT"` in Cargo.toml and `"license": "MIT"` in npm/package.json
- [ ] `cargo metadata --no-deps` parses cleanly
- [ ] Verify the new LICENSE file contains the standard MIT text
- [ ] No remaining "Apache" license references in tracked, non-vendored files