### PR TITLE
Release v0.4.0: Tier 1 cloud-native tools + tool provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,15 @@ jobs:
       - name: Install binaryen (wasm-opt)
         run: sudo apt-get update && sudo apt-get install -y binaryen
 
+      - name: Install wasi-sdk (C toolchain so zstd-sys builds for wasm32-wasip1)
+        run: |
+          ver=33.0
+          curl -sL "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-${ver}-x86_64-linux.tar.gz" | sudo tar xz -C /opt
+          sdk=/opt/wasi-sdk-${ver}-x86_64-linux
+          echo "CC_wasm32_wasip1=$sdk/bin/clang" >> "$GITHUB_ENV"
+          echo "AR_wasm32_wasip1=$sdk/bin/llvm-ar" >> "$GITHUB_ENV"
+          echo "CFLAGS_wasm32_wasip1=--sysroot=$sdk/share/wasi-sysroot" >> "$GITHUB_ENV"
+
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,15 @@ jobs:
       - name: Install binaryen (wasm-opt)
         run: sudo apt-get update && sudo apt-get install -y binaryen
 
+      - name: Install wasi-sdk (C toolchain so zstd-sys builds for wasm32-wasip1)
+        run: |
+          ver=33.0
+          curl -sL "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-${ver}-x86_64-linux.tar.gz" | sudo tar xz -C /opt
+          sdk=/opt/wasi-sdk-${ver}-x86_64-linux
+          echo "CC_wasm32_wasip1=$sdk/bin/clang" >> "$GITHUB_ENV"
+          echo "AR_wasm32_wasip1=$sdk/bin/llvm-ar" >> "$GITHUB_ENV"
+          echo "CFLAGS_wasm32_wasip1=--sysroot=$sdk/share/wasi-sysroot" >> "$GITHUB_ENV"
+
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -733,16 +733,19 @@ dependencies = [
 
 [[package]]
 name = "geolibre-tools"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
+ "parquet",
+ "png 0.17.16",
  "serde_json",
  "wbcore",
  "wbraster",
+ "wbvector",
 ]
 
 [[package]]
 name = "geolibre-wasm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -2968,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "wbcore"
 version = "0.1.1"
-source = "git+https://github.com/opengeos/whitebox-wasm#be91a7836182a95cf75ca600111410f85c2f4140"
+source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
 dependencies = [
  "serde",
  "serde_json",
@@ -2978,7 +2981,7 @@ dependencies = [
 [[package]]
 name = "wbgeotiff"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#be91a7836182a95cf75ca600111410f85c2f4140"
+source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -2997,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "wbhdf"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#be91a7836182a95cf75ca600111410f85c2f4140"
+source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3008,7 +3011,7 @@ dependencies = [
 [[package]]
 name = "wblidar"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#be91a7836182a95cf75ca600111410f85c2f4140"
+source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
 dependencies = [
  "rayon",
  "wbhdf",
@@ -3019,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "wbprojection"
 version = "0.3.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#be91a7836182a95cf75ca600111410f85c2f4140"
+source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
 dependencies = [
  "thiserror 1.0.69",
  "wide 1.5.0",
@@ -3028,7 +3031,7 @@ dependencies = [
 [[package]]
 name = "wbraster"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#be91a7836182a95cf75ca600111410f85c2f4140"
+source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -3051,7 +3054,7 @@ dependencies = [
 [[package]]
 name = "wbspatialstats"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#be91a7836182a95cf75ca600111410f85c2f4140"
+source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
 dependencies = [
  "log",
  "nalgebra",
@@ -3066,7 +3069,7 @@ dependencies = [
 [[package]]
 name = "wbtools_oss"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#be91a7836182a95cf75ca600111410f85c2f4140"
+source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
 dependencies = [
  "bincode",
  "chrono",
@@ -3096,7 +3099,7 @@ dependencies = [
 [[package]]
 name = "wbtopology"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#be91a7836182a95cf75ca600111410f85c2f4140"
+source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
 dependencies = [
  "rayon",
  "robust",
@@ -3106,8 +3109,9 @@ dependencies = [
 [[package]]
 name = "wbvector"
 version = "0.1.4"
-source = "git+https://github.com/opengeos/whitebox-wasm#be91a7836182a95cf75ca600111410f85c2f4140"
+source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
 dependencies = [
+ "bytes",
  "flatbuffers 24.12.23",
  "osmpbfreader",
  "parquet",

--- a/README.md
+++ b/README.md
@@ -62,9 +62,20 @@ tools.mjs                        crates/geolibre-cli (main.rs)
 
 ## GeoLibre-authored tools
 
-In addition to the whitebox suite, `geolibre-tools` ships pure-Rust ports of the
-DEM depression/mount algorithms from [`opengeos/lidar`](https://github.com/opengeos/lidar)
-(no GDAL, RichDEM, SciPy, or scikit-image dependency; they run in WASM):
+In addition to the whitebox suite, `geolibre-tools` ships cloud-native I/O and
+rendering tools that the whitebox suite lacks (all pure-Rust, running in WASM):
+
+| Tool id | What it does |
+|---|---|
+| `reproject_raster` | Reproject (warp) a raster into a target EPSG CRS, with selectable resampling. |
+| `render_raster_png` | Render a raster band to a PNG through a colormap (viridis/magma/turbo/terrain/grayscale); no-data becomes transparent. |
+| `raster_to_tiles` | Slice a raster into a Web Mercator (EPSG:3857) XYZ PNG tile pyramid for web maps. |
+| `write_geoparquet` | Convert any supported vector format to GeoParquet, Hilbert-sorted with a bbox covering column and ZSTD compression by default. |
+| `read_geoparquet` | Read GeoParquet and convert it to another vector format (or store it in memory). |
+
+It also ships pure-Rust ports of the DEM depression/mount algorithms from
+[`opengeos/lidar`](https://github.com/opengeos/lidar) (no GDAL, RichDEM, SciPy,
+or scikit-image dependency; they run in WASM):
 
 | Tool id | Source | What it does |
 |---|---|---|

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-cli/src/main.rs
+++ b/crates/geolibre-cli/src/main.rs
@@ -25,7 +25,7 @@
 //!
 //! Exit codes: `0` success, `1` tool/execution error, `2` usage error.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::process::ExitCode;
 
 use serde_json::Value;
@@ -41,6 +41,32 @@ fn build_registry() -> ToolRegistry {
         registry.register(tool);
     }
     registry
+}
+
+/// The ids of GeoLibre-authored tools, so manifests can be tagged with their
+/// provenance (`"geolibre"` vs `"whitebox"`).
+fn geolibre_tool_ids() -> HashSet<String> {
+    geolibre_tools::geolibre_tools()
+        .iter()
+        .map(|t| t.metadata().id.to_string())
+        .collect()
+}
+
+/// Adds a `"source"` field (`"geolibre"` or `"whitebox"`) to a manifest JSON
+/// object based on its `id`. The upstream `ToolManifest` has no such field, so
+/// it is injected here at serialization time.
+fn tag_source(manifest: &mut Value, geolibre_ids: &HashSet<String>) {
+    if let Some(obj) = manifest.as_object_mut() {
+        let is_geolibre = obj
+            .get("id")
+            .and_then(Value::as_str)
+            .map(|id| geolibre_ids.contains(id))
+            .unwrap_or(false);
+        obj.insert(
+            "source".to_string(),
+            Value::String(if is_geolibre { "geolibre" } else { "whitebox" }.to_string()),
+        );
+    }
 }
 
 fn main() -> ExitCode {
@@ -60,9 +86,15 @@ fn main() -> ExitCode {
         }
         "manifests" => {
             let registry = build_registry();
-            match serde_json::to_string(&registry.manifests()) {
-                Ok(json) => {
-                    println!("{json}");
+            let geolibre_ids = geolibre_tool_ids();
+            match serde_json::to_value(registry.manifests()) {
+                Ok(mut value) => {
+                    if let Some(arr) = value.as_array_mut() {
+                        for m in arr.iter_mut() {
+                            tag_source(m, &geolibre_ids);
+                        }
+                    }
+                    println!("{value}");
                     ExitCode::SUCCESS
                 }
                 Err(e) => {
@@ -78,9 +110,10 @@ fn main() -> ExitCode {
             };
             let registry = build_registry();
             match registry.manifests().into_iter().find(|m| &m.id == id) {
-                Some(manifest) => match serde_json::to_string(&manifest) {
-                    Ok(json) => {
-                        println!("{json}");
+                Some(manifest) => match serde_json::to_value(&manifest) {
+                    Ok(mut value) => {
+                        tag_source(&mut value, &geolibre_tool_ids());
+                        println!("{value}");
                         ExitCode::SUCCESS
                     }
                     Err(e) => {

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -13,5 +13,13 @@ description = "New geospatial tools that extend the whitebox_next_gen suite, sur
 # Built on opengeos/whitebox-wasm; see geolibre-cli/Cargo.toml.
 wbcore = { git = "https://github.com/opengeos/whitebox-wasm" }
 wbraster = { git = "https://github.com/opengeos/whitebox-wasm" }
+# GeoParquet read/write lives behind wbvector's `geoparquet` feature.
+wbvector = { git = "https://github.com/opengeos/whitebox-wasm", features = ["geoparquet"] }
+# Pulled in transitively by wbvector's geoparquet feature; named directly so the
+# GeoParquet tools can choose the compression codec (ZSTD by default).
+parquet = "58.3"
 
 serde_json = "1"
+# Pure-Rust PNG encoder (miniz_oxide backend), used by render_raster_png and
+# raster_to_tiles. Compiles cleanly to wasm32-wasip1.
+png = "0.17"

--- a/crates/geolibre-tools/src/geoparquet_io.rs
+++ b/crates/geolibre-tools/src/geoparquet_io.rs
@@ -1,0 +1,232 @@
+//! GeoLibre tools: read and write GeoParquet, the cloud-native columnar vector
+//! format. The whitebox suite has no GeoParquet I/O tool (the capability lives
+//! in `wbvector` behind a feature flag); these expose it.
+//!
+//! - `write_geoparquet`: read any supported vector format, write `.parquet`.
+//! - `read_geoparquet`: read `.parquet`, write any supported vector format
+//!   (or store in memory).
+
+use parquet::basic::{Compression, ZstdLevel};
+use serde_json::{json, Value};
+use wbcore::{
+    LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata,
+    ToolParamSpec, ToolRunResult,
+};
+use wbvector::geoparquet::{write_with_options, GeoParquetWriteOptions};
+use wbvector::Layer;
+
+use crate::hilbert::hilbert_for_point;
+use crate::vector_common::{ensure_parent_dir, load_input_layer, parse_optional_str, write_or_store_layer};
+
+/// Converts any supported vector dataset to GeoParquet.
+pub struct WriteGeoParquetTool;
+
+impl Tool for WriteGeoParquetTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "write_geoparquet",
+            display_name: "Write GeoParquet",
+            summary: "Convert a vector dataset (GeoJSON, Shapefile, FlatGeobuf, GeoPackage, ...) to GeoParquet, Hilbert-sorted and ZSTD-compressed by default.",
+            category: ToolCategory::Conversion,
+            license_tier: LicenseTier::Open,
+            params: vec![
+                ToolParamSpec {
+                    name: "input",
+                    description: "Input vector file path (format auto-detected) or in-memory handle.",
+                    required: true,
+                },
+                ToolParamSpec {
+                    name: "output",
+                    description: "Output GeoParquet file path (e.g. /work/data.parquet).",
+                    required: true,
+                },
+                ToolParamSpec {
+                    name: "compression",
+                    description: "Column compression: zstd (default), snappy, gzip, or uncompressed.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "hilbert_sort",
+                    description: "Sort features along a Hilbert curve for spatial locality (default true).",
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        require_str(args, "input")?;
+        require_str(args, "output")?;
+        if let Some(c) = args.get("compression").and_then(Value::as_str) {
+            parse_compression(c)?;
+        }
+        Ok(())
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = require_str(args, "input")?;
+        let output = require_str(args, "output")?;
+        let compression = match args.get("compression").and_then(Value::as_str) {
+            Some(c) => parse_compression(c)?,
+            None => Compression::ZSTD(ZstdLevel::default()),
+        };
+        let hilbert = args
+            .get("hilbert_sort")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+
+        ctx.progress.info("reading input vector");
+        let mut layer = load_input_layer(input)?;
+        let feature_count = layer.len();
+
+        if hilbert {
+            ctx.progress.info("Hilbert-sorting features");
+            hilbert_sort(&mut layer);
+        }
+
+        ctx.progress.info("writing GeoParquet");
+        let options = GeoParquetWriteOptions::new().with_compression(compression);
+        ensure_parent_dir(output)?;
+        write_with_options(&layer, output, &options)
+            .map_err(|e| ToolError::Execution(format!("failed writing GeoParquet: {e}")))?;
+
+        let mut outputs = std::collections::BTreeMap::new();
+        outputs.insert("output".to_string(), json!(output));
+        outputs.insert("feature_count".to_string(), json!(feature_count));
+        outputs.insert("compression".to_string(), json!(compression_name(compression)));
+        outputs.insert("hilbert_sorted".to_string(), json!(hilbert));
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+/// Reorders a layer's features along a Hilbert curve computed from each
+/// feature's bounding-box center over the dataset extent. Features without a
+/// geometry keep their relative order at the end.
+fn hilbert_sort(layer: &mut Layer) {
+    // Dataset extent over all feature bounding boxes.
+    let (mut min_x, mut min_y, mut max_x, mut max_y) =
+        (f64::INFINITY, f64::INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY);
+    for f in &layer.features {
+        if let Some(b) = f.geometry.as_ref().and_then(|g| g.bbox()) {
+            min_x = min_x.min(b.min_x);
+            min_y = min_y.min(b.min_y);
+            max_x = max_x.max(b.max_x);
+            max_y = max_y.max(b.max_y);
+        }
+    }
+    if !min_x.is_finite() {
+        return; // nothing georeferenced to sort
+    }
+
+    // Key each feature; geometry-less features sort last (key = u64::MAX).
+    let mut indexed: Vec<(u64, usize)> = layer
+        .features
+        .iter()
+        .enumerate()
+        .map(|(i, f)| {
+            let key = match f.geometry.as_ref().and_then(|g| g.bbox()) {
+                Some(b) => hilbert_for_point(
+                    0.5 * (b.min_x + b.max_x),
+                    0.5 * (b.min_y + b.max_y),
+                    min_x,
+                    min_y,
+                    max_x,
+                    max_y,
+                ),
+                None => u64::MAX,
+            };
+            (key, i)
+        })
+        .collect();
+    indexed.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+
+    let original = std::mem::take(&mut layer.features);
+    let mut slots: Vec<Option<_>> = original.into_iter().map(Some).collect();
+    layer.features = indexed
+        .into_iter()
+        .map(|(_, i)| slots[i].take().expect("each index used once"))
+        .collect();
+}
+
+/// Parses a compression-codec name into a parquet `Compression`.
+fn parse_compression(name: &str) -> Result<Compression, ToolError> {
+    match name.trim().to_ascii_lowercase().as_str() {
+        "zstd" => Ok(Compression::ZSTD(ZstdLevel::default())),
+        "snappy" | "snap" => Ok(Compression::SNAPPY),
+        "gzip" | "gz" => Ok(Compression::GZIP(Default::default())),
+        "uncompressed" | "none" | "off" => Ok(Compression::UNCOMPRESSED),
+        other => Err(ToolError::Validation(format!(
+            "unknown compression '{other}' (expected zstd, snappy, gzip, or uncompressed)"
+        ))),
+    }
+}
+
+/// Short stable name for a compression codec, for the result JSON.
+fn compression_name(c: Compression) -> &'static str {
+    match c {
+        Compression::ZSTD(_) => "zstd",
+        Compression::SNAPPY => "snappy",
+        Compression::GZIP(_) => "gzip",
+        Compression::UNCOMPRESSED => "uncompressed",
+        _ => "other",
+    }
+}
+
+/// Reads GeoParquet and writes it to another vector format (or memory).
+pub struct ReadGeoParquetTool;
+
+impl Tool for ReadGeoParquetTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "read_geoparquet",
+            display_name: "Read GeoParquet",
+            summary: "Read a GeoParquet file and convert it to another vector format (or store it in memory).",
+            category: ToolCategory::Conversion,
+            license_tier: LicenseTier::Open,
+            params: vec![
+                ToolParamSpec {
+                    name: "input",
+                    description: "Input GeoParquet file path (e.g. /work/data.parquet).",
+                    required: true,
+                },
+                ToolParamSpec {
+                    name: "output",
+                    description: "Optional output vector path; format is taken from its extension (.geojson, .fgb, .shp, .gpkg, ...). If omitted, the layer is stored in memory.",
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        require_str(args, "input")?;
+        Ok(())
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = require_str(args, "input")?;
+        let output = parse_optional_str(args, "output")?;
+
+        ctx.progress.info("reading GeoParquet");
+        let layer = load_input_layer(input)?;
+        let feature_count = layer.len();
+
+        ctx.progress.info("writing output vector");
+        let out_path = write_or_store_layer(layer, output)?;
+
+        let mut outputs = std::collections::BTreeMap::new();
+        outputs.insert("output".to_string(), json!(out_path));
+        outputs.insert("feature_count".to_string(), json!(feature_count));
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+/// Fetches a required, non-empty string parameter.
+fn require_str<'a>(args: &'a ToolArgs, key: &str) -> Result<&'a str, ToolError> {
+    match args.get(key).and_then(Value::as_str) {
+        Some(s) if !s.trim().is_empty() => Ok(s),
+        _ => Err(ToolError::Validation(format!(
+            "missing required string parameter '{key}'"
+        ))),
+    }
+}

--- a/crates/geolibre-tools/src/hilbert.rs
+++ b/crates/geolibre-tools/src/hilbert.rs
@@ -1,0 +1,102 @@
+//! Hilbert-curve spatial ordering for vector features.
+//!
+//! Sorting features along a Hilbert curve clusters spatially-near records on
+//! disk, which is what makes a GeoParquet file's row-group and page statistics
+//! (and a bbox covering) effective for spatial pruning. We map each feature's
+//! bounding-box center into a `2^ORDER` x `2^ORDER` grid over the dataset
+//! extent, then sort by the curve distance of that cell.
+
+/// Grid resolution per axis is `2^ORDER`. 16 gives 65536 cells per axis, the
+/// de-facto standard used by GeoParquet writers (e.g. GeoPandas, ogr2ogr).
+const ORDER: u32 = 16;
+
+/// Maps grid coordinates `(x, y)` in `[0, 2^ORDER)` to their Hilbert-curve
+/// distance `d`.
+pub fn xy_to_hilbert(x: u32, y: u32) -> u64 {
+    xy_to_hilbert_order(x, y, ORDER)
+}
+
+/// Classic iterative xy->d Hilbert transform for an arbitrary grid `order`
+/// (grid is `2^order` per axis). Factored out so tests can exhaustively check a
+/// small grid.
+fn xy_to_hilbert_order(mut x: u32, mut y: u32, order: u32) -> u64 {
+    let n: u32 = 1 << order;
+    let mut d: u64 = 0;
+    let mut s: u32 = n / 2;
+    while s > 0 {
+        let rx = u32::from((x & s) > 0);
+        let ry = u32::from((y & s) > 0);
+        d += (s as u64) * (s as u64) * ((3 * rx) ^ ry) as u64;
+        // Rotate the quadrant so the curve stays continuous.
+        if ry == 0 {
+            if rx == 1 {
+                x = s.wrapping_sub(1).wrapping_sub(x) & (n - 1);
+                y = s.wrapping_sub(1).wrapping_sub(y) & (n - 1);
+            }
+            std::mem::swap(&mut x, &mut y);
+        }
+        s /= 2;
+    }
+    d
+}
+
+/// Computes the Hilbert distance for a point at `(px, py)` within the extent
+/// `[min_x, max_x] x [min_y, max_y]`. Degenerate (zero-width) axes map to the
+/// grid center, so a constant-coordinate dataset still sorts deterministically.
+pub fn hilbert_for_point(px: f64, py: f64, min_x: f64, min_y: f64, max_x: f64, max_y: f64) -> u64 {
+    let max_cell = ((1u32 << ORDER) - 1) as f64;
+    let scale = |v: f64, lo: f64, hi: f64| -> u32 {
+        if hi <= lo {
+            (max_cell / 2.0) as u32
+        } else {
+            (((v - lo) / (hi - lo)) * max_cell).round().clamp(0.0, max_cell) as u32
+        }
+    };
+    xy_to_hilbert(scale(px, min_x, max_x), scale(py, min_y, max_y))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_a_bijection_over_a_small_grid() {
+        // Over a 4x4 grid the distances must be exactly 0..16 with no repeats.
+        let order = 2;
+        let n = 1u32 << order;
+        let mut seen = vec![false; (n * n) as usize];
+        for y in 0..n {
+            for x in 0..n {
+                let d = xy_to_hilbert_order(x, y, order) as usize;
+                assert!(d < seen.len(), "distance out of range");
+                assert!(!seen[d], "distance {d} produced twice");
+                seen[d] = true;
+            }
+        }
+        assert!(seen.into_iter().all(|s| s), "every distance must be hit");
+    }
+
+    #[test]
+    fn consecutive_distances_are_grid_adjacent() {
+        // The defining Hilbert property: stepping d -> d+1 moves exactly one
+        // cell (Manhattan distance 1).
+        let order = 2;
+        let n = 1u32 << order;
+        let mut by_d: Vec<(u32, u32)> = vec![(0, 0); (n * n) as usize];
+        for y in 0..n {
+            for x in 0..n {
+                by_d[xy_to_hilbert_order(x, y, order) as usize] = (x, y);
+            }
+        }
+        for w in by_d.windows(2) {
+            let manhattan = w[0].0.abs_diff(w[1].0) + w[0].1.abs_diff(w[1].1);
+            assert_eq!(manhattan, 1, "consecutive cells must be adjacent");
+        }
+    }
+
+    #[test]
+    fn degenerate_extent_does_not_panic() {
+        let d = hilbert_for_point(5.0, 5.0, 5.0, 5.0, 5.0, 5.0);
+        assert!(d > 0);
+    }
+}

--- a/crates/geolibre-tools/src/lib.rs
+++ b/crates/geolibre-tools/src/lib.rs
@@ -13,9 +13,16 @@ mod delineate_mounts;
 mod dem_filter;
 mod extract_sinks;
 mod fill;
+mod geoparquet_io;
+mod hilbert;
 mod polygonize;
 mod raster_normalize;
+mod raster_to_tiles;
 mod regions;
+mod render;
+mod render_png;
+mod reproject_raster;
+mod vector_common;
 
 use wbcore::Tool;
 
@@ -38,6 +45,11 @@ pub fn geolibre_tools() -> Vec<Box<dyn Tool>> {
         Box::new(extract_sinks::ExtractSinksTool),
         Box::new(delineate_depressions::DelineateDepressionsTool),
         Box::new(delineate_mounts::DelineateMountsTool),
+        Box::new(reproject_raster::ReprojectRasterTool),
+        Box::new(render_png::RenderPngTool),
+        Box::new(raster_to_tiles::RasterToTilesTool),
+        Box::new(geoparquet_io::WriteGeoParquetTool),
+        Box::new(geoparquet_io::ReadGeoParquetTool),
     ]
 }
 

--- a/crates/geolibre-tools/src/raster_to_tiles.rs
+++ b/crates/geolibre-tools/src/raster_to_tiles.rs
@@ -1,0 +1,310 @@
+//! GeoLibre tool: slice a raster into a Web Mercator XYZ tile pyramid of PNGs.
+//!
+//! The suite has no web-map tiling output. This reprojects the input to
+//! EPSG:3857, then for each requested zoom level samples the standard slippy-map
+//! tile grid into 256x256 RGBA PNGs written as `{output_dir}/{z}/{x}/{y}.png`.
+//! Fully transparent (no-data) tiles are skipped so the pyramid stays sparse.
+
+use std::path::Path;
+
+use serde_json::{json, Value};
+use wbcore::{
+    LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata,
+    ToolParamSpec, ToolRunResult,
+};
+use wbraster::{NodataPolicy, Raster, ResampleMethod};
+
+use crate::common::load_input_raster;
+use crate::render::{encode_png_rgba, normalize, Colormap};
+use crate::reproject_raster::parse_resample;
+
+/// EPSG:3857 (Web Mercator) world half-extent in meters: pi * 6378137.
+const ORIGIN: f64 = 20_037_508.342_789_244;
+const TILE_SIZE: usize = 256;
+const WEB_MERCATOR_EPSG: u32 = 3857;
+/// Safety cap so a too-wide zoom range cannot generate an unbounded pyramid.
+const MAX_TILES: usize = 4096;
+
+/// Renders a raster into a Web Mercator XYZ PNG tile pyramid.
+pub struct RasterToTilesTool;
+
+impl Tool for RasterToTilesTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "raster_to_tiles",
+            display_name: "Raster to XYZ Tiles",
+            summary: "Slice a raster into a Web Mercator (EPSG:3857) XYZ PNG tile pyramid for web maps.",
+            category: ToolCategory::Conversion,
+            license_tier: LicenseTier::Open,
+            params: vec![
+                ToolParamSpec {
+                    name: "input",
+                    description: "Input raster file path. Must carry a source CRS (EPSG or WKT).",
+                    required: true,
+                },
+                ToolParamSpec {
+                    name: "output_dir",
+                    description: "Output directory for the {z}/{x}/{y}.png tile tree (e.g. /work/tiles).",
+                    required: true,
+                },
+                ToolParamSpec {
+                    name: "min_zoom",
+                    description: "Minimum zoom level (default: a single native zoom matching the raster resolution).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "max_zoom",
+                    description: "Maximum zoom level (default: same as min_zoom).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "band",
+                    description: "1-based band to render (default 1).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "colormap",
+                    description: "Colormap: viridis (default), magma, turbo, terrain, or grayscale.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "method",
+                    description: "Resampling method for reprojection and sampling: bilinear (default), nearest, cubic.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "min",
+                    description: "Value mapped to the low end of the colormap (default: band minimum).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "max",
+                    description: "Value mapped to the high end of the colormap (default: band maximum).",
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        if args.get("input").and_then(Value::as_str).is_none() {
+            return Err(ToolError::Validation(
+                "missing required string parameter 'input'".to_string(),
+            ));
+        }
+        if args.get("output_dir").and_then(Value::as_str).is_none() {
+            return Err(ToolError::Validation(
+                "missing required string parameter 'output_dir'".to_string(),
+            ));
+        }
+        if let Some(c) = args.get("colormap").and_then(Value::as_str) {
+            Colormap::parse(c)?;
+        }
+        if let Some(m) = args.get("method").and_then(Value::as_str) {
+            parse_resample(m)?;
+        }
+        Ok(())
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = args
+            .get("input")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::Validation("missing required parameter 'input'".to_string()))?;
+        let output_dir = args
+            .get("output_dir")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                ToolError::Validation("missing required parameter 'output_dir'".to_string())
+            })?
+            .trim_end_matches('/');
+        let band_1based = args.get("band").and_then(Value::as_u64).unwrap_or(1).max(1);
+        let band = (band_1based - 1) as isize;
+        let colormap = match args.get("colormap").and_then(Value::as_str) {
+            Some(c) => Colormap::parse(c)?,
+            None => Colormap::Viridis,
+        };
+        let method = match args.get("method").and_then(Value::as_str) {
+            Some(m) => parse_resample(m)?,
+            None => ResampleMethod::Bilinear,
+        };
+
+        let raster = load_input_raster(input)?;
+        if band as usize >= raster.bands {
+            return Err(ToolError::Validation(format!(
+                "band {band_1based} out of range (raster has {} band(s))",
+                raster.bands
+            )));
+        }
+
+        // Work in Web Mercator: reproject unless the source is already 3857.
+        ctx.progress.info("reprojecting to EPSG:3857");
+        let merc: Raster = if raster.crs.epsg == Some(WEB_MERCATOR_EPSG) {
+            raster
+        } else {
+            if raster.crs.epsg.is_none()
+                && raster.crs.wkt.is_none()
+                && raster.crs.proj4.is_none()
+            {
+                return Err(ToolError::Validation(
+                    "input raster has no source CRS (EPSG/WKT/PROJ); cannot tile".to_string(),
+                ));
+            }
+            raster
+                .reproject_to_epsg(WEB_MERCATOR_EPSG, method)
+                .map_err(|e| ToolError::Execution(format!("reprojection to 3857 failed: {e}")))?
+        };
+
+        let stats = merc
+            .statistics_band(band)
+            .map_err(|e| ToolError::Execution(format!("failed computing band statistics: {e}")))?;
+        let min = args.get("min").and_then(Value::as_f64).unwrap_or(stats.min);
+        let max = args.get("max").and_then(Value::as_f64).unwrap_or(stats.max);
+        if !min.is_finite() || !max.is_finite() {
+            return Err(ToolError::Execution(
+                "raster band has no finite values to render".to_string(),
+            ));
+        }
+
+        // Resolve the zoom range. Default to a single native zoom that matches
+        // the reprojected pixel size.
+        let native = native_zoom(merc.cell_size_x.abs());
+        let min_zoom = args
+            .get("min_zoom")
+            .and_then(Value::as_u64)
+            .map(|z| z as u32)
+            .unwrap_or(native);
+        let max_zoom = args
+            .get("max_zoom")
+            .and_then(Value::as_u64)
+            .map(|z| z as u32)
+            .unwrap_or(min_zoom)
+            .max(min_zoom);
+        if max_zoom > 24 {
+            return Err(ToolError::Validation(
+                "max_zoom must be <= 24".to_string(),
+            ));
+        }
+
+        let ex = merc.extent();
+        let mut written = 0usize;
+        let mut total = 0usize;
+        let mut zoom_summaries = Vec::new();
+
+        for z in min_zoom..=max_zoom {
+            let n = 1u64 << z; // tiles per side
+            let span = (2.0 * ORIGIN) / n as f64; // tile width in meters
+            let (tx_min, tx_max) = tile_range(ex.x_min, ex.x_max, -ORIGIN, span, n);
+            // Y tile index increases southward (row 0 at the top / north).
+            let (ty_min, ty_max) = tile_range(ORIGIN - ex.y_max, ORIGIN - ex.y_min, 0.0, span, n);
+
+            let count_this_zoom =
+                ((tx_max - tx_min + 1) as usize) * ((ty_max - ty_min + 1) as usize);
+            total += count_this_zoom;
+            if total > MAX_TILES {
+                return Err(ToolError::Validation(format!(
+                    "tile pyramid would exceed {MAX_TILES} tiles; narrow the zoom range (min_zoom/max_zoom)"
+                )));
+            }
+
+            let mut z_written = 0usize;
+            for tx in tx_min..=tx_max {
+                for ty in ty_min..=ty_max {
+                    let x0 = -ORIGIN + tx as f64 * span;
+                    let y_top = ORIGIN - ty as f64 * span;
+                    if let Some(png) =
+                        render_tile(&merc, band, x0, y_top, span, method, colormap, min, max)?
+                    {
+                        let path = format!("{output_dir}/{z}/{tx}/{ty}.png");
+                        write_bytes(&path, &png)?;
+                        z_written += 1;
+                    }
+                }
+            }
+            written += z_written;
+            zoom_summaries.push(json!({ "zoom": z, "tiles_written": z_written }));
+            ctx.progress
+                .progress((z - min_zoom + 1) as f64 / (max_zoom - min_zoom + 1) as f64);
+        }
+
+        let mut outputs = std::collections::BTreeMap::new();
+        outputs.insert("output_dir".to_string(), json!(output_dir));
+        outputs.insert("min_zoom".to_string(), json!(min_zoom));
+        outputs.insert("max_zoom".to_string(), json!(max_zoom));
+        outputs.insert("tiles_written".to_string(), json!(written));
+        outputs.insert("zooms".to_string(), json!(zoom_summaries));
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+/// Renders one 256x256 tile. Returns `None` if every pixel is no-data / outside
+/// the raster, so the caller can skip writing an empty tile.
+#[allow(clippy::too_many_arguments)]
+fn render_tile(
+    merc: &Raster,
+    band: isize,
+    x0: f64,
+    y_top: f64,
+    span: f64,
+    method: ResampleMethod,
+    colormap: Colormap,
+    min: f64,
+    max: f64,
+) -> Result<Option<Vec<u8>>, ToolError> {
+    let px_span = span / TILE_SIZE as f64;
+    let mut rgba = vec![0u8; TILE_SIZE * TILE_SIZE * 4];
+    let mut any = false;
+    for py in 0..TILE_SIZE {
+        let wy = y_top - (py as f64 + 0.5) * px_span;
+        for px in 0..TILE_SIZE {
+            let wx = x0 + (px as f64 + 0.5) * px_span;
+            if let Some(v) = merc.sample_world(band, wx, wy, method, NodataPolicy::Strict) {
+                let idx = (py * TILE_SIZE + px) * 4;
+                let [r, g, b] = colormap.rgb(normalize(v, min, max));
+                rgba[idx] = r;
+                rgba[idx + 1] = g;
+                rgba[idx + 2] = b;
+                rgba[idx + 3] = 255;
+                any = true;
+            }
+        }
+    }
+    if !any {
+        return Ok(None);
+    }
+    Ok(Some(encode_png_rgba(&rgba, TILE_SIZE as u32, TILE_SIZE as u32)?))
+}
+
+/// Inclusive tile-index range covering `[lo, hi]` along an axis whose tile 0
+/// starts at `axis_origin`, with `span`-meter tiles and `n` tiles total.
+fn tile_range(lo: f64, hi: f64, axis_origin: f64, span: f64, n: u64) -> (u64, u64) {
+    let max_idx = n - 1;
+    let a = (((lo - axis_origin) / span).floor()).clamp(0.0, max_idx as f64) as u64;
+    // Subtract a tiny epsilon so a coordinate exactly on a tile boundary does
+    // not pull in the next (empty) tile.
+    let b = (((hi - axis_origin) / span - 1e-9).floor()).clamp(0.0, max_idx as f64) as u64;
+    (a.min(b), a.max(b))
+}
+
+/// Zoom level whose 256px tiles have a pixel size closest to `cell_size_m`.
+fn native_zoom(cell_size_m: f64) -> u32 {
+    if cell_size_m <= 0.0 {
+        return 0;
+    }
+    // res(z) = (2*ORIGIN) / (256 * 2^z); solve for z so res ~= cell_size_m.
+    let z = ((2.0 * ORIGIN / (TILE_SIZE as f64 * cell_size_m)).log2()).round();
+    z.clamp(0.0, 24.0) as u32
+}
+
+/// Writes bytes to a path, creating parent directories as needed.
+fn write_bytes(path: &str, bytes: &[u8]) -> Result<(), ToolError> {
+    if let Some(parent) = Path::new(path).parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                ToolError::Execution(format!("failed creating tile directory: {e}"))
+            })?;
+        }
+    }
+    std::fs::write(path, bytes)
+        .map_err(|e| ToolError::Execution(format!("failed writing tile: {e}")))
+}

--- a/crates/geolibre-tools/src/render.rs
+++ b/crates/geolibre-tools/src/render.rs
@@ -1,0 +1,149 @@
+//! Shared raster rendering: map raster values through a colormap to RGBA and
+//! encode PNGs. Used by `render_raster_png` (one image) and `raster_to_tiles`
+//! (a pyramid of 256x256 web-map tiles).
+//!
+//! Colormaps are stored as a handful of evenly spaced RGB control stops and
+//! linearly interpolated, which keeps the table tiny while looking smooth.
+
+use wbcore::ToolError;
+
+/// A perceptual or terrain colormap selectable by name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Colormap {
+    Grayscale,
+    Viridis,
+    Magma,
+    Terrain,
+    Turbo,
+}
+
+impl Colormap {
+    /// Parses a colormap name (case-insensitive). Defaults are chosen by the
+    /// caller; this returns an error for unknown names so typos are caught.
+    pub fn parse(name: &str) -> Result<Self, ToolError> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "grayscale" | "greyscale" | "gray" | "grey" => Ok(Self::Grayscale),
+            "viridis" => Ok(Self::Viridis),
+            "magma" => Ok(Self::Magma),
+            "terrain" => Ok(Self::Terrain),
+            "turbo" => Ok(Self::Turbo),
+            other => Err(ToolError::Validation(format!(
+                "unknown colormap '{other}' (expected grayscale, viridis, magma, terrain, or turbo)"
+            ))),
+        }
+    }
+
+    /// Evenly spaced RGB control stops for this colormap.
+    fn stops(self) -> &'static [[u8; 3]] {
+        match self {
+            Self::Grayscale => &[[0, 0, 0], [255, 255, 255]],
+            // Compact subsamples of matplotlib's viridis / magma / turbo.
+            Self::Viridis => &[
+                [68, 1, 84],
+                [72, 40, 120],
+                [62, 74, 137],
+                [49, 104, 142],
+                [38, 130, 142],
+                [31, 158, 137],
+                [53, 183, 121],
+                [110, 206, 88],
+                [181, 222, 43],
+                [253, 231, 37],
+            ],
+            Self::Magma => &[
+                [0, 0, 4],
+                [28, 16, 68],
+                [79, 18, 123],
+                [129, 37, 129],
+                [181, 54, 122],
+                [229, 80, 100],
+                [251, 135, 97],
+                [254, 194, 135],
+                [252, 253, 191],
+            ],
+            Self::Turbo => &[
+                [48, 18, 59],
+                [70, 107, 227],
+                [40, 187, 226],
+                [49, 242, 153],
+                [150, 254, 70],
+                [225, 220, 55],
+                [253, 152, 39],
+                [223, 67, 19],
+                [122, 4, 3],
+            ],
+            // A hypsometric land ramp: greens -> tans -> browns -> white.
+            Self::Terrain => &[
+                [0, 97, 71],
+                [54, 145, 79],
+                [149, 191, 99],
+                [223, 217, 140],
+                [199, 165, 110],
+                [151, 110, 75],
+                [132, 95, 90],
+                [255, 255, 255],
+            ],
+        }
+    }
+
+    /// Maps a normalized value in [0, 1] to an RGB triple via piecewise-linear
+    /// interpolation between control stops. Values are clamped to [0, 1].
+    pub fn rgb(self, t: f64) -> [u8; 3] {
+        let stops = self.stops();
+        let t = t.clamp(0.0, 1.0);
+        if stops.len() == 1 {
+            return stops[0];
+        }
+        let scaled = t * (stops.len() - 1) as f64;
+        let i = (scaled.floor() as usize).min(stops.len() - 2);
+        let frac = scaled - i as f64;
+        let a = stops[i];
+        let b = stops[i + 1];
+        [
+            lerp(a[0], b[0], frac),
+            lerp(a[1], b[1], frac),
+            lerp(a[2], b[2], frac),
+        ]
+    }
+}
+
+fn lerp(a: u8, b: u8, frac: f64) -> u8 {
+    (a as f64 + (b as f64 - a as f64) * frac).round().clamp(0.0, 255.0) as u8
+}
+
+/// Linear stretch from a value range to [0, 1]. A zero-width range maps every
+/// valid value to 0.0 so a constant raster still renders.
+#[inline]
+pub fn normalize(value: f64, min: f64, max: f64) -> f64 {
+    if max <= min {
+        0.0
+    } else {
+        (value - min) / (max - min)
+    }
+}
+
+/// Encodes an RGBA8 buffer (`width*height*4` bytes, row-major) as a PNG byte
+/// stream. Alpha 0 marks no-data / out-of-bounds pixels, so tiles overlay
+/// cleanly on a web map.
+pub fn encode_png_rgba(rgba: &[u8], width: u32, height: u32) -> Result<Vec<u8>, ToolError> {
+    let expected = width as usize * height as usize * 4;
+    if rgba.len() != expected {
+        return Err(ToolError::Execution(format!(
+            "RGBA buffer length {} does not match {width}x{height}x4 = {expected}",
+            rgba.len()
+        )));
+    }
+    let mut out = Vec::new();
+    {
+        let mut encoder = png::Encoder::new(&mut out, width, height);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder
+            .write_header()
+            .map_err(|e| ToolError::Execution(format!("failed writing PNG header: {e}")))?;
+        writer
+            .write_image_data(rgba)
+            .map_err(|e| ToolError::Execution(format!("failed writing PNG data: {e}")))?;
+    }
+    Ok(out)
+}

--- a/crates/geolibre-tools/src/render_png.rs
+++ b/crates/geolibre-tools/src/render_png.rs
@@ -1,0 +1,164 @@
+//! GeoLibre tool: render a single raster band to a PNG image through a colormap.
+//!
+//! The whitebox suite has RGB composite tools but nothing that renders one
+//! continuous band through a colormap to a web-displayable PNG. No-data cells
+//! become fully transparent, so the image overlays cleanly.
+
+use std::path::Path;
+
+use serde_json::{json, Value};
+use wbcore::{
+    LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata,
+    ToolParamSpec, ToolRunResult,
+};
+
+use crate::common::load_input_raster;
+use crate::render::{encode_png_rgba, normalize, Colormap};
+
+/// Renders one band of a raster to an RGBA PNG using a named colormap, stretched
+/// across the band's value range (or an explicit min/max).
+pub struct RenderPngTool;
+
+impl Tool for RenderPngTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "render_raster_png",
+            display_name: "Render Raster to PNG",
+            summary: "Render a single raster band to a PNG image through a colormap (no-data becomes transparent).",
+            category: ToolCategory::Raster,
+            license_tier: LicenseTier::Open,
+            params: vec![
+                ToolParamSpec {
+                    name: "input",
+                    description: "Input raster file path.",
+                    required: true,
+                },
+                ToolParamSpec {
+                    name: "output",
+                    description: "Output PNG file path (e.g. /work/preview.png).",
+                    required: true,
+                },
+                ToolParamSpec {
+                    name: "band",
+                    description: "1-based band to render (default 1).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "colormap",
+                    description: "Colormap: viridis (default), magma, turbo, terrain, or grayscale.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "min",
+                    description: "Value mapped to the low end of the colormap (default: band minimum).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "max",
+                    description: "Value mapped to the high end of the colormap (default: band maximum).",
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        if args.get("input").and_then(Value::as_str).is_none() {
+            return Err(ToolError::Validation(
+                "missing required string parameter 'input'".to_string(),
+            ));
+        }
+        if args.get("output").and_then(Value::as_str).is_none() {
+            return Err(ToolError::Validation(
+                "missing required string parameter 'output'".to_string(),
+            ));
+        }
+        if let Some(c) = args.get("colormap").and_then(Value::as_str) {
+            Colormap::parse(c)?;
+        }
+        Ok(())
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = args
+            .get("input")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::Validation("missing required parameter 'input'".to_string()))?;
+        let output = args
+            .get("output")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::Validation("missing required parameter 'output'".to_string()))?;
+        let band_1based = args.get("band").and_then(Value::as_u64).unwrap_or(1).max(1);
+        let band = (band_1based - 1) as isize;
+        let colormap = match args.get("colormap").and_then(Value::as_str) {
+            Some(c) => Colormap::parse(c)?,
+            None => Colormap::Viridis,
+        };
+
+        let raster = load_input_raster(input)?;
+        if band as usize >= raster.bands {
+            return Err(ToolError::Validation(format!(
+                "band {band_1based} out of range (raster has {} band(s))",
+                raster.bands
+            )));
+        }
+
+        // Resolve the stretch range from args or the band's statistics.
+        let stats = raster
+            .statistics_band(band)
+            .map_err(|e| ToolError::Execution(format!("failed computing band statistics: {e}")))?;
+        let min = args.get("min").and_then(Value::as_f64).unwrap_or(stats.min);
+        let max = args.get("max").and_then(Value::as_f64).unwrap_or(stats.max);
+        if !min.is_finite() || !max.is_finite() {
+            return Err(ToolError::Execution(
+                "raster band has no finite values to render".to_string(),
+            ));
+        }
+
+        let rows = raster.rows as isize;
+        let cols = raster.cols as isize;
+        let nodata = raster.nodata;
+
+        ctx.progress.info("rendering");
+        let mut rgba = vec![0u8; (rows * cols * 4) as usize];
+        for row in 0..rows {
+            for col in 0..cols {
+                let v = raster.get(band, row, col);
+                let idx = ((row * cols + col) * 4) as usize;
+                if v == nodata || !v.is_finite() {
+                    continue; // leave fully transparent
+                }
+                let [r, g, b] = colormap.rgb(normalize(v, min, max));
+                rgba[idx] = r;
+                rgba[idx + 1] = g;
+                rgba[idx + 2] = b;
+                rgba[idx + 3] = 255;
+            }
+            ctx.progress.progress((row as f64 + 1.0) / rows as f64);
+        }
+
+        let png = encode_png_rgba(&rgba, cols as u32, rows as u32)?;
+        write_bytes(output, &png)?;
+
+        let mut outputs = std::collections::BTreeMap::new();
+        outputs.insert("output".to_string(), json!(output));
+        outputs.insert("width".to_string(), json!(cols));
+        outputs.insert("height".to_string(), json!(rows));
+        outputs.insert("min".to_string(), json!(min));
+        outputs.insert("max".to_string(), json!(max));
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+/// Writes bytes to a path, creating parent directories as needed.
+fn write_bytes(path: &str, bytes: &[u8]) -> Result<(), ToolError> {
+    if let Some(parent) = Path::new(path).parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                ToolError::Execution(format!("failed creating output directory: {e}"))
+            })?;
+        }
+    }
+    std::fs::write(path, bytes)
+        .map_err(|e| ToolError::Execution(format!("failed writing output file: {e}")))
+}

--- a/crates/geolibre-tools/src/reproject_raster.rs
+++ b/crates/geolibre-tools/src/reproject_raster.rs
@@ -1,0 +1,146 @@
+//! GeoLibre tool: reproject (warp) a raster to a target EPSG CRS.
+//!
+//! The whitebox suite ships `reproject_vector` but no raster warp; this fills
+//! that gap by wrapping `wbraster`'s built-in reprojection. The source CRS is
+//! read from the raster's own metadata, so only a destination EPSG is required.
+
+use serde_json::{json, Value};
+use wbcore::{
+    LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata,
+    ToolParamSpec, ToolRunResult,
+};
+use wbraster::ResampleMethod;
+
+use crate::common::{load_input_raster, parse_optional_output, write_or_store_output};
+
+/// Warps a raster into a target EPSG coordinate reference system, resampling
+/// the grid with the requested method.
+pub struct ReprojectRasterTool;
+
+impl Tool for ReprojectRasterTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "reproject_raster",
+            display_name: "Reproject Raster",
+            summary: "Reproject (warp) a raster into a target EPSG coordinate reference system.",
+            category: ToolCategory::Raster,
+            license_tier: LicenseTier::Open,
+            params: vec![
+                ToolParamSpec {
+                    name: "input",
+                    description: "Input raster file path. Must carry a source CRS (EPSG or WKT).",
+                    required: true,
+                },
+                ToolParamSpec {
+                    name: "epsg",
+                    description: "Destination EPSG code, e.g. 3857 (Web Mercator) or 4326 (WGS84).",
+                    required: true,
+                },
+                ToolParamSpec {
+                    name: "method",
+                    description: "Resampling method: nearest (default), bilinear, cubic, lanczos, average, min, max, mode, median.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "output",
+                    description: "Optional output raster path. If omitted, the result is stored in memory.",
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        if args.get("input").and_then(Value::as_str).is_none() {
+            return Err(ToolError::Validation(
+                "missing required string parameter 'input'".to_string(),
+            ));
+        }
+        if parse_epsg(args).is_err() {
+            return Err(ToolError::Validation(
+                "missing or invalid required parameter 'epsg' (a positive EPSG code)".to_string(),
+            ));
+        }
+        if let Some(m) = args.get("method").and_then(Value::as_str) {
+            parse_resample(m)?;
+        }
+        Ok(())
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = args
+            .get("input")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::Validation("missing required parameter 'input'".to_string()))?;
+        let dst_epsg = parse_epsg(args)?;
+        let method = match args.get("method").and_then(Value::as_str) {
+            Some(m) => parse_resample(m)?,
+            None => ResampleMethod::Nearest,
+        };
+        let output = parse_optional_output(args, "output")?;
+
+        let raster = load_input_raster(input)?;
+        let src_epsg = raster.crs.epsg;
+        if src_epsg.is_none() && raster.crs.wkt.is_none() && raster.crs.proj4.is_none() {
+            return Err(ToolError::Validation(
+                "input raster has no source CRS (EPSG/WKT/PROJ); cannot reproject".to_string(),
+            ));
+        }
+
+        ctx.progress
+            .info(&format!("reprojecting to EPSG:{dst_epsg}"));
+        let reprojected = raster
+            .reproject_to_epsg(dst_epsg, method)
+            .map_err(|e| ToolError::Execution(format!("reprojection failed: {e}")))?;
+
+        let (rows, cols) = (reprojected.rows, reprojected.cols);
+        let out_path = write_or_store_output(reprojected, output)?;
+
+        let mut outputs = std::collections::BTreeMap::new();
+        outputs.insert("output".to_string(), json!(out_path));
+        outputs.insert("dst_epsg".to_string(), json!(dst_epsg));
+        if let Some(src) = src_epsg {
+            outputs.insert("src_epsg".to_string(), json!(src));
+        }
+        outputs.insert("rows".to_string(), json!(rows));
+        outputs.insert("cols".to_string(), json!(cols));
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+/// Parses the required positive `epsg` parameter (accepts a number or a numeric
+/// string).
+fn parse_epsg(args: &ToolArgs) -> Result<u32, ToolError> {
+    let raw = args
+        .get("epsg")
+        .ok_or_else(|| ToolError::Validation("missing required parameter 'epsg'".to_string()))?;
+    let code = match raw {
+        Value::Number(n) => n.as_u64(),
+        Value::String(s) => s.trim().parse::<u64>().ok(),
+        _ => None,
+    };
+    match code {
+        Some(c) if c > 0 && c <= u32::MAX as u64 => Ok(c as u32),
+        _ => Err(ToolError::Validation(
+            "parameter 'epsg' must be a positive EPSG code".to_string(),
+        )),
+    }
+}
+
+/// Maps a resampling-method name to a `ResampleMethod`.
+pub fn parse_resample(name: &str) -> Result<ResampleMethod, ToolError> {
+    match name.trim().to_ascii_lowercase().as_str() {
+        "nearest" | "nn" => Ok(ResampleMethod::Nearest),
+        "bilinear" | "linear" => Ok(ResampleMethod::Bilinear),
+        "cubic" | "bicubic" => Ok(ResampleMethod::Cubic),
+        "lanczos" => Ok(ResampleMethod::Lanczos),
+        "average" | "mean" => Ok(ResampleMethod::Average),
+        "min" | "minimum" => Ok(ResampleMethod::Min),
+        "max" | "maximum" => Ok(ResampleMethod::Max),
+        "mode" => Ok(ResampleMethod::Mode),
+        "median" => Ok(ResampleMethod::Median),
+        other => Err(ToolError::Validation(format!(
+            "unknown resampling method '{other}'"
+        ))),
+    }
+}

--- a/crates/geolibre-tools/src/vector_common.rs
+++ b/crates/geolibre-tools/src/vector_common.rs
@@ -1,0 +1,67 @@
+//! Shared vector I/O for GeoLibre tools: load a `Layer` from a file path or an
+//! in-memory (`memory://`) handle, and write it back to a path or memory.
+//!
+//! Mirrors `common.rs` (the raster equivalent) but for `wbvector::Layer`.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+use wbcore::{ToolArgs, ToolError};
+use wbvector::{memory_store, Layer, VectorFormat};
+
+/// Parses an optional string parameter (absent / null / empty -> None).
+pub fn parse_optional_str<'a>(args: &'a ToolArgs, key: &str) -> Result<Option<&'a str>, ToolError> {
+    match args.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(s)) if s.trim().is_empty() => Ok(None),
+        Some(Value::String(s)) => Ok(Some(s.as_str())),
+        Some(_) => Err(ToolError::Validation(format!(
+            "parameter '{key}' must be a string when provided"
+        ))),
+    }
+}
+
+/// Loads a vector layer from a file path (format auto-detected) or an in-memory
+/// (`memory://`) handle.
+pub fn load_input_layer(path: &str) -> Result<Layer, ToolError> {
+    if memory_store::vector_is_memory_path(path) {
+        let id = memory_store::vector_path_to_id(path)
+            .ok_or_else(|| ToolError::Validation("malformed in-memory vector path".to_string()))?;
+        let arc: Arc<Layer> = memory_store::get_vector_arc_by_id(id)
+            .ok_or_else(|| ToolError::Validation(format!("unknown in-memory vector id '{id}'")))?;
+        return Ok((*arc).clone());
+    }
+    wbvector::read(path)
+        .map_err(|e| ToolError::Execution(format!("failed reading input vector: {e}")))
+}
+
+/// Writes `layer` to `output_path` using the format implied by its extension,
+/// or stores it in memory and returns a `memory://` handle when no path is given.
+pub fn write_or_store_layer(layer: Layer, output_path: Option<&str>) -> Result<String, ToolError> {
+    match output_path {
+        Some(path) => {
+            let fmt = VectorFormat::detect(path)
+                .map_err(|e| ToolError::Validation(format!("unsupported output path: {e}")))?;
+            ensure_parent_dir(path)?;
+            wbvector::write(&layer, path, fmt)
+                .map_err(|e| ToolError::Execution(format!("failed writing output vector: {e}")))?;
+            Ok(path.to_string())
+        }
+        None => {
+            let id = memory_store::put_vector(layer);
+            Ok(memory_store::make_vector_memory_path(&id))
+        }
+    }
+}
+
+/// Creates the parent directory of `path` if needed.
+pub fn ensure_parent_dir(path: &str) -> Result<(), ToolError> {
+    if let Some(parent) = std::path::Path::new(path).parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                ToolError::Execution(format!("failed creating output directory: {e}"))
+            })?;
+        }
+    }
+    Ok(())
+}

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/demo/index.html
+++ b/demo/index.html
@@ -48,6 +48,10 @@
       .field .desc { font-size: 0.78rem; opacity: 0.7; margin-bottom: 0.3rem; }
       .field input[type="text"], .field input[type="number"], .field select { width: 100%; }
       .placeholder { opacity: 0.6; padding: 2rem 1rem; text-align: center; }
+      .src { display: inline-block; font-size: 0.64rem; font-weight: 700; letter-spacing: 0.03em; padding: 0.05rem 0.35rem; border-radius: 4px; vertical-align: middle; }
+      .src.geolibre { background: #2563eb; color: #fff; }
+      .src.whitebox { background: rgba(127,127,127,0.22); color: inherit; }
+      .list .item .name { display: flex; align-items: center; gap: 0.4rem; }
     </style>
   </head>
   <body>
@@ -92,6 +96,13 @@
       const basename = (p) => String(p).split(/[\\/]/).pop();
       const esc = (s) => String(s).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
 
+      // Provenance badge: GeoLibre-authored vs whitebox tool. Defaults to
+      // whitebox if the manifest predates the "source" field.
+      function sourceBadge(t) {
+        const geo = t.source === "geolibre";
+        return `<span class="src ${geo ? "geolibre" : "whitebox"}" title="${geo ? "GeoLibre-authored tool" : "whitebox_next_gen tool"}">${geo ? "GeoLibre" : "Whitebox"}</span>`;
+      }
+
       // Best-known value for a param: prefer the worked example, fall back to the default.
       function hintValue(tool, name) {
         const ex = tool.examples && tool.examples[0] && tool.examples[0].args;
@@ -130,7 +141,7 @@
           .map(
             (t) =>
               `<div class="item${selected && selected.id === t.id ? " active" : ""}" data-id="${t.id}">` +
-              `<div class="name">${esc(t.display_name)}</div>` +
+              `<div class="name">${esc(t.display_name)}${sourceBadge(t)}</div>` +
               `<div class="sum">${esc(t.summary)}</div></div>`,
           )
           .join("");
@@ -200,7 +211,7 @@
           `<input type="text" id="f_extra" data-extra="1" placeholder="--flag=value ..." /></div>`;
 
         d.innerHTML =
-          `<h2>${esc(t.display_name)}<span class="badge">${esc(t.category)}</span><span class="badge">${esc(t.id)}</span></h2>` +
+          `<h2>${esc(t.display_name)} ${sourceBadge(t)}<span class="badge">${esc(t.category)}</span><span class="badge">${esc(t.id)}</span></h2>` +
           `<p class="muted" style="margin-top:0">${esc(t.summary)}</p>` +
           inferredNote +
           `<form id="form" onsubmit="return false">${fields}${extraField}</form>` +

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/npm/tools.d.ts
+++ b/npm/tools.d.ts
@@ -4,7 +4,9 @@ export interface ToolResult {
   exitCode: number;
   /** Captured stdout/stderr lines. */
   stdout: string[];
-  /** New files the tool wrote, keyed by filename (e.g. the --output path's basename). */
+  /** New files the tool wrote, keyed by path relative to /work. Top-level
+   *  outputs use their basename (e.g. "slope.tif"); tools that write a tree
+   *  (e.g. raster_to_tiles) use nested keys like "tiles/15/4779/16383.png". */
   files: Record<string, Uint8Array>;
 }
 

--- a/npm/tools.mjs
+++ b/npm/tools.mjs
@@ -52,10 +52,21 @@ async function exec(argv, inputFiles) {
   let exitCode = 0;
   try { exitCode = wasi.start(inst); }
   catch (e) { if (e && e.constructor && e.constructor.name === "WASIProcExit") exitCode = e.code; else throw e; }
+  // Collect every new file under /work, recursing into subdirectories so tools
+  // that write a tree (e.g. raster_to_tiles' {z}/{x}/{y}.png) are surfaced too.
+  // Keys are paths relative to /work (nested files use "/" separators).
   const files = {};
-  for (const [name, entry] of work.dir.contents) {
-    if (entry.data && !inNames.has(name)) files[name] = entry.data;
-  }
+  const walk = (dir, prefix) => {
+    for (const [name, entry] of dir.contents) {
+      const rel = prefix ? `${prefix}/${name}` : name;
+      if (entry && entry.contents) {
+        walk(entry, rel); // subdirectory
+      } else if (entry && entry.data && !(prefix === "" && inNames.has(name))) {
+        files[rel] = entry.data; // new file (top-level inputs excluded)
+      }
+    }
+  };
+  walk(work.dir, "");
   return { exitCode, stdout, files };
 }
 


### PR DESCRIPTION
## Summary
- Add five pure-Rust, WASM-ready tools to `geolibre-tools`:
  - `reproject_raster` - warp a raster into a target EPSG CRS (selectable resampling)
  - `render_raster_png` - render a band through a colormap (viridis/magma/turbo/terrain/grayscale) to a PNG, no-data transparent
  - `raster_to_tiles` - Web Mercator (EPSG:3857) XYZ PNG tile pyramid for web maps
  - `write_geoparquet` / `read_geoparquet` - GeoParquet I/O, Hilbert-sorted with a GeoParquet 1.1 bbox covering column and ZSTD compression by default
- Tag each tool manifest with provenance (`geolibre` vs `whitebox`) and show a source badge per tool in the demo.
- Recurse into subdirectories when collecting tool outputs (`tools.mjs`) so `raster_to_tiles`' nested `{z}/{x}/{y}.png` tree is returned to JS.
- Bump crates and the npm package to 0.4.0.

GeoParquet support depends on opengeos/whitebox-wasm#1 (bbox covering column + WASM-safe in-memory parquet reader), now merged; the git deps point at the merged commit.

## Test plan
- [x] `cargo test -p geolibre-tools` (22 passing, incl. Hilbert curve correctness)
- [x] Native + `wasm32-wasip1` builds green
- [x] Browser verification (Playwright, real US states GeoJSON): write_geoparquet -> read_geoparquet round-trips 52 features with California density 241.7 and geometry preserved exactly; reproject_raster 32610 -> 4326 output carries EPSG:4326
- [ ] Release CI builds WASM artifacts and publishes `geolibre-wasm@0.4.0` on the `v0.4.0` tag