### PR TITLE
fix(demo): correct output extension and add a tool-source filter

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -70,6 +70,11 @@
         <select id="category" disabled style="width:100%;margin-top:0.5rem;">
           <option value="">All categories</option>
         </select>
+        <select id="source" disabled style="width:100%;margin-top:0.5rem;">
+          <option value="">All sources</option>
+          <option value="geolibre">GeoLibre tools</option>
+          <option value="whitebox">Whitebox tools</option>
+        </select>
         <p class="muted" style="margin:0.3rem 0;font-size:0.8rem;">
           <span id="count">0</span> tools
         </p>
@@ -103,6 +108,19 @@
         return `<span class="src ${geo ? "geolibre" : "whitebox"}" title="${geo ? "GeoLibre-authored tool" : "whitebox_next_gen tool"}">${geo ? "GeoLibre" : "Whitebox"}</span>`;
       }
 
+      // Default filename for an output param. Don't assume .tif: prefer the
+      // worked example value, then the "e.g. <path>" in the description (which
+      // carries the right extension, e.g. .parquet/.png, or a dir like tiles),
+      // then any ".ext" mentioned, and only then fall back to .tif.
+      function outputDefault(tool, param, hint) {
+        if (hint != null && String(hint).includes(".")) return basename(String(hint));
+        const desc = param.description || "";
+        const eg = desc.match(/e\.g\.?\s+([^\s,)]+)/i);
+        if (eg) return basename(eg[1]);
+        const ext = desc.match(/\.([a-z0-9]{2,8})\b/i);
+        return `${tool.id}.${ext ? ext[1] : "tif"}`;
+      }
+
       // Best-known value for a param: prefer the worked example, fall back to the default.
       function hintValue(tool, name) {
         const ex = tool.examples && tool.examples[0] && tool.examples[0].args;
@@ -128,7 +146,9 @@
       function renderList() {
         const f = $("filter").value.trim().toLowerCase();
         const cat = $("category").value;
+        const src = $("source").value;
         const shown = manifests.filter((t) => {
+          if (src && (t.source || "whitebox") !== src) return false;
           if (cat && t.category !== cat) return false;
           if (!f) return true;
           return (t.id + " " + t.display_name + " " + t.summary + " " + (t.tags || []).join(" "))
@@ -188,7 +208,7 @@
               control = `<input type="file" id="${id}" data-name="${p.name}" data-kind="file" />` +
                 `<div class="desc">Leave empty to use ${c.primary ? "the sample DEM" : "no file"}${note}.</div>`;
             } else if (c.kind === "output") {
-              const val = basename(c.hint ?? `${t.id}.tif`);
+              const val = outputDefault(t, p, c.hint);
               control = `<input type="text" id="${id}" data-name="${p.name}" data-kind="output" value="${esc(val)}" />`;
             } else if (c.kind === "bool") {
               const checked = c.hint ? " checked" : "";
@@ -330,6 +350,15 @@
             cat.insertAdjacentHTML("beforeend", `<option value="${esc(name)}">${esc(name)} (${counts[name]})</option>`);
           cat.disabled = false;
           cat.addEventListener("change", renderList);
+
+          // Provenance filter: count GeoLibre vs whitebox tools and wire it up.
+          const srcCounts = { geolibre: 0, whitebox: 0 };
+          for (const t of manifests) srcCounts[t.source === "geolibre" ? "geolibre" : "whitebox"]++;
+          const src = $("source");
+          src.options[1].textContent = `GeoLibre tools (${srcCounts.geolibre})`;
+          src.options[2].textContent = `Whitebox tools (${srcCounts.whitebox})`;
+          src.disabled = false;
+          src.addEventListener("change", renderList);
 
           renderList();
           const filter = $("filter");


### PR DESCRIPTION
## Summary
- Fix the output filename default: it hardcoded `.tif`, so vector/PNG tools wrongly showed `<tool>.tif` (e.g. `write_geoparquet.tif`). The default is now derived from the tool's own metadata - the worked example, then the `e.g. <path>` in the param description (carrying the right extension or a directory name), then any `.ext` mentioned, and only then `.tif`. Results: `write_geoparquet` -> `data.parquet`, `render_raster_png` -> `preview.png`, `raster_to_tiles` -> `tiles`, `read_geoparquet` -> `read_geoparquet.geojson`, rasters stay `.tif`.
- Add a source dropdown ("All sources / GeoLibre tools (N) / Whitebox tools (N)") to filter the tool list by provenance, composing with the existing text and category filters.

## Test plan
- [x] Browser check (Playwright): output defaults are `data.parquet` / `preview.png` / `tiles` / `read_geoparquet.geojson`; `slope` keeps its example `slope.tif`
- [x] Source filter: GeoLibre shows exactly the 10 GeoLibre tools (all badged GeoLibre); Whitebox shows 733
- [ ] Pages redeploys the demo