### PR TITLE
Release v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-tools"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "parquet",
  "png 0.17.16",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-wasm"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolibre-wasm"
-version = "0.4.0"
+version = "0.4.1"
 description = "Run the GeoLibre / whitebox_next_gen geospatial tool suite (WASM/WASI) from Python."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/geolibre_wasm/__init__.py
+++ b/python/src/geolibre_wasm/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "runtime_path",
 ]
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/python/src/geolibre_wasm/_core.py
+++ b/python/src/geolibre_wasm/_core.py
@@ -28,7 +28,7 @@ _DOWNLOAD_TIMEOUT = 120
 
 #: Release whose ``geolibre-cli.wasm`` asset this wrapper downloads by default.
 #: Kept in sync with the package version's ``vMAJOR.MINOR.PATCH`` tag.
-RUNTIME_VERSION = "v0.4.0"
+RUNTIME_VERSION = "v0.4.1"
 _ASSET = f"geolibre-cli-{RUNTIME_VERSION}.wasm"
 _RELEASE_URL = (
     "https://github.com/opengeos/geolibre-rust/releases/download/"


### PR DESCRIPTION
## Summary
- Patch release that exercises the new **PyPI Trusted Publishing** path for the `geolibre-wasm` Python package, alongside the existing npm publish.
- Bump crates, the npm package, and the Python package (incl. the runtime version it downloads) to 0.4.1.

## Test plan
- [ ] Release CI builds the WASM, publishes `geolibre-wasm@0.4.1` to npm, and publishes `geolibre-wasm==0.4.1` to PyPI via Trusted Publishing on the `v0.4.1` tag
- [ ] GitHub release attaches the WASM artifacts + the Python wheel/sdist