### PR TITLE
Release v0.4.2: bundle LICENSE in the Python package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-tools"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "parquet",
  "png 0.17.16",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-wasm"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/python/LICENSE
+++ b/python/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Qiusheng Wu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,11 +4,12 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolibre-wasm"
-version = "0.4.1"
+version = "0.4.2"
 description = "Run the GeoLibre / whitebox_next_gen geospatial tool suite (WASM/WASI) from Python."
 readme = "README.md"
 requires-python = ">=3.9"
 license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "Qiusheng Wu", email = "giswqs@gmail.com" }]
 keywords = ["geospatial", "gis", "wasm", "wasi", "raster", "vector", "geoparquet", "whitebox", "geolibre"]
 classifiers = [

--- a/python/src/geolibre_wasm/__init__.py
+++ b/python/src/geolibre_wasm/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "runtime_path",
 ]
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/python/src/geolibre_wasm/_core.py
+++ b/python/src/geolibre_wasm/_core.py
@@ -28,7 +28,7 @@ _DOWNLOAD_TIMEOUT = 120
 
 #: Release whose ``geolibre-cli.wasm`` asset this wrapper downloads by default.
 #: Kept in sync with the package version's ``vMAJOR.MINOR.PATCH`` tag.
-RUNTIME_VERSION = "v0.4.1"
+RUNTIME_VERSION = "v0.4.2"
 _ASSET = f"geolibre-cli-{RUNTIME_VERSION}.wasm"
 _RELEASE_URL = (
     "https://github.com/opengeos/geolibre-rust/releases/download/"


### PR DESCRIPTION
## Summary
- The published `geolibre-wasm` PyPI tarball had no license file. Add `python/LICENSE` (MIT) and declare it via PEP 639 `license-files`, so it ships in both the sdist (`/LICENSE`) and the wheel (`.dist-info/licenses/LICENSE`).
- Bump crates, the npm package, and the Python package to 0.4.2.

## Test plan
- [x] `python -m build` produces a wheel + sdist that both contain `LICENSE`; `twine check` passes
- [ ] Release CI publishes `geolibre-wasm@0.4.2` to npm and PyPI on the `v0.4.2` tag