### PR TITLE
Release v0.4.3: Colab notebook, recipes, and robust URL inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-tools"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "parquet",
  "png 0.17.16",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-wasm"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/geolibre-wasm.svg)](https://www.npmjs.com/package/geolibre-wasm)
 [![CI](https://github.com/opengeos/geolibre-rust/actions/workflows/ci.yml/badge.svg)](https://github.com/opengeos/geolibre-rust/actions/workflows/ci.yml)
 [![license](https://img.shields.io/npm/l/geolibre-wasm.svg)](https://github.com/opengeos/geolibre-rust#license)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/geolibre-rust/blob/main/examples/geolibre_wasm.ipynb)
 
 A pure-Rust geospatial toolkit for [GeoLibre](https://github.com/opengeos/GeoLibre),
 built on [`opengeos/whitebox-wasm`](https://github.com/opengeos/whitebox-wasm)
@@ -207,6 +208,11 @@ The `python/` package (`geolibre-wasm` on PyPI, `import geolibre_wasm`) runs the
 same WASI tool runner in-process via `wasmtime`, mirroring the JS `./tools` API.
 No native install, GDAL, or server.
 
+Try it in your browser, no setup:
+[**Open the quickstart notebook in Google Colab**](https://colab.research.google.com/github/opengeos/geolibre-rust/blob/main/examples/geolibre_wasm.ipynb)
+([`examples/geolibre_wasm.ipynb`](examples/geolibre_wasm.ipynb)) -- it reads and
+processes a real DEM and building footprints end to end.
+
 ```bash
 pip install geolibre-wasm
 ```
@@ -242,6 +248,97 @@ gl.run_tool(
 
 The runtime `.wasm` is downloaded from the matching release on first use (or set
 `GEOLIBRE_WASM`). See [`python/README.md`](python/README.md) for details.
+
+## Recipes: reading and processing various formats
+
+The examples below use the Python API; the JavaScript `runTool` takes the same
+`args` and `input` (just `camelCase`). Each `input` value can be `bytes`, an
+`http(s)` URL, or a local path. Output files come back in `result.files` keyed by
+their `/work`-relative path. These all run against the real tool suite.
+
+### Vector (GeoParquet, GeoJSON, FlatGeobuf, Shapefile, GeoPackage, ...)
+
+```python
+import geolibre_wasm as gl
+
+# Convert GeoJSON -> GeoParquet (Hilbert-sorted, bbox covering, ZSTD by default)
+gj = open("cities.geojson", "rb").read()
+gl.run_tool("write_geoparquet",
+            args=["--input=/work/in.geojson", "--output=/work/out.parquet"],
+            input={"in.geojson": gj})
+
+# Read GeoParquet -> any vector format (driver picked from the output extension:
+# .geojson, .fgb, .shp, .gpkg, ...). Omit --output to keep it in memory.
+res = gl.run_tool("read_geoparquet",
+                  args=["--input=/work/in.parquet", "--output=/work/out.fgb"],
+                  input={"in.parquet": "https://example.com/data.parquet"})
+open("out.fgb", "wb").write(res.files["out.fgb"])
+
+# Buffer features, then simplify (Douglas-Peucker)
+res = gl.run_tool("buffer_vector",
+                  args=["--input=/work/in.geojson", "--distance=25", "--output=/work/buf.geojson"],
+                  input={"in.geojson": gj})
+res = gl.run_tool("simplify_features",
+                  args=["--input=/work/buf.geojson", "--tolerance=5", "--output=/work/simple.geojson"],
+                  input={"buf.geojson": res.files["buf.geojson"]})
+
+# Add geometry attributes (area / perimeter / centroid, ...)
+gl.run_tool("add_geometry_attributes",
+            args=["--input=/work/in.geojson", "--area=true", "--centroid=true",
+                  "--output=/work/attrs.geojson"],
+            input={"in.geojson": gj})
+```
+
+`reproject_vector` works the same, but the input must carry a source CRS (a
+Shapefile `.prj`, or a GeoParquet/GeoPackage with CRS metadata), e.g.
+`args=["--input=/work/in.fgb", "--epsg=3857", "--output=/work/out.fgb"]`.
+
+### LiDAR point clouds (LAS / LAZ)
+
+```python
+import geolibre_wasm as gl
+
+cloud = open("cloud.las", "rb").read()        # or a .laz, or an http(s) URL
+
+# Summary report (point count, bounds, density, ...). Output must be .txt/.html.
+res = gl.run_tool("lidar_info",
+                  args=["--input=/work/cloud.las", "--output=/work/info.txt"],
+                  input={"cloud.las": cloud})
+print(res.files["info.txt"].decode())
+
+# Rasterize to a DEM (IDW) -> Cloud Optimized GeoTIFF
+res = gl.run_tool("lidar_idw_interpolation",
+                  args=["--input=/work/cloud.las", "--resolution=1.0", "--output=/work/dtm.tif"],
+                  input={"cloud.las": cloud})
+open("dtm.tif", "wb").write(res.files["dtm.tif"])
+
+# Drop unwanted classes (comma-delimited list; e.g. exclude 1=unclassified, 7=noise)
+gl.run_tool("filter_lidar_classes",
+            args=["--input=/work/cloud.las", "--excluded_classes=1,7", "--output=/work/clean.las"],
+            input={"cloud.las": cloud})
+
+# Export points to a Shapefile
+gl.run_tool("las_to_shapefile",
+            args=["--input=/work/cloud.las", "--output=/work/points.shp"],
+            input={"cloud.las": cloud})
+```
+
+### Raster (GeoTIFF / COG)
+
+```python
+dem = open("dem.tif", "rb").read()            # or an http(s) URL to a COG
+
+# Warp to Web Mercator, then render a PNG preview through a colormap
+gl.run_tool("reproject_raster",
+            args=["--input=/work/dem.tif", "--epsg=3857", "--output=/work/merc.tif"],
+            input={"dem.tif": dem})
+gl.run_tool("render_raster_png",
+            args=["--input=/work/dem.tif", "--colormap=terrain", "--output=/work/preview.png"],
+            input={"dem.tif": dem})
+```
+
+Run `gl.list_tools()` for all 740+ tool ids and `gl.list_manifests()` for each
+tool's parameters and provenance (`"source": "geolibre" | "whitebox"`).
 
 ## GeoLibre integration
 

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/examples/geolibre_wasm.ipynb
+++ b/examples/geolibre_wasm.ipynb
@@ -35,7 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q geolibre-wasm"
+    "%pip install -q \"geolibre-wasm>=0.4.3\""
    ]
   },
   {
@@ -69,6 +69,35 @@
     "\n",
     "\n",
     "print(len(gl.list_tools()), \"tools available\")  # first call downloads the runtime once\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dcebdffc",
+   "metadata": {},
+   "source": [
+    "### Tip: pass a URL or path directly\n",
+    "\n",
+    "Instead of downloading first, an `input` value can be an `http(s)` URL (fetched\n",
+    "for you) or a local file path. The download-once pattern above is more efficient\n",
+    "when you reuse the same file across several calls; the shortcut is handy for\n",
+    "one-off runs and works the same for raster and vector inputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b576ca9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Same result as the cells below, but geolibre_wasm fetches the URL for you:\n",
+    "res = gl.run_tool(\n",
+    "    \"slope\",\n",
+    "    args=[\"--input=/work/dem.tif\", \"--output=/work/slope.tif\", \"--units=degrees\"],\n",
+    "    input={\"dem.tif\": \"https://data.source.coop/giswqs/opengeos/dem.tif\"},\n",
+    ")\n",
+    "print(res.exit_code, res.stdout[-1])"
    ]
   },
   {

--- a/examples/geolibre_wasm.ipynb
+++ b/examples/geolibre_wasm.ipynb
@@ -1,0 +1,288 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a22cbed4",
+   "metadata": {},
+   "source": [
+    "# GeoLibre WASM quickstart\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/geolibre-rust/blob/main/examples/geolibre_wasm.ipynb)\n",
+    "\n",
+    "Run the [`geolibre-rust`](https://github.com/opengeos/geolibre-rust) geospatial\n",
+    "tool suite (the `whitebox_next_gen` tools plus GeoLibre's own) from Python. The\n",
+    "tools are a single WebAssembly (WASI) module executed in-process via `wasmtime`,\n",
+    "so there is **no native install, no GDAL, and no server**.\n",
+    "\n",
+    "This notebook reads and processes real public datasets:\n",
+    "\n",
+    "- raster DEM: `https://data.source.coop/giswqs/opengeos/dem.tif`\n",
+    "- vector buildings: `https://data.source.coop/giswqs/opengeos/las-vegas-buildings.geojson`\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0d599ea",
+   "metadata": {},
+   "source": [
+    "## Install"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43bd3f98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q geolibre-wasm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "321129ff",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "The tools run over an in-memory `/work` filesystem: you pass input files as\n",
+    "`bytes` keyed by name, and any new files come back in `result.files` keyed by\n",
+    "their `/work`-relative path. Here we fetch the sample datasets with `urllib`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3f79da0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib.request\n",
+    "import geolibre_wasm as gl\n",
+    "\n",
+    "\n",
+    "def fetch(url):\n",
+    "    \"\"\"Download a file to bytes (with a browser User-Agent for picky hosts).\"\"\"\n",
+    "    req = urllib.request.Request(url, headers={\"User-Agent\": \"Mozilla/5.0\"})\n",
+    "    with urllib.request.urlopen(req) as r:\n",
+    "        return r.read()\n",
+    "\n",
+    "\n",
+    "print(len(gl.list_tools()), \"tools available\")  # first call downloads the runtime once\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f214afee",
+   "metadata": {},
+   "source": [
+    "## Raster: a DEM (Cloud Optimized GeoTIFF)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8378fd69",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DEM_URL = \"https://data.source.coop/giswqs/opengeos/dem.tif\"\n",
+    "dem = fetch(DEM_URL)\n",
+    "\n",
+    "# Slope (degrees) -> Cloud Optimized GeoTIFF\n",
+    "res = gl.run_tool(\n",
+    "    \"slope\",\n",
+    "    args=[\"--input=/work/dem.tif\", \"--output=/work/slope.tif\", \"--units=degrees\"],\n",
+    "    input={\"dem.tif\": dem},\n",
+    ")\n",
+    "assert res.exit_code == 0, res.stdout\n",
+    "print(res.stdout[-1])\n",
+    "open(\"slope.tif\", \"wb\").write(res.files[\"slope.tif\"])  # save the COG\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c50bec0",
+   "metadata": {},
+   "source": [
+    "Render a colormapped PNG preview and show it inline:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26514a71",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Image\n",
+    "\n",
+    "res = gl.run_tool(\n",
+    "    \"render_raster_png\",\n",
+    "    args=[\"--input=/work/dem.tif\", \"--colormap=terrain\", \"--output=/work/dem.png\"],\n",
+    "    input={\"dem.tif\": dem},\n",
+    ")\n",
+    "Image(data=res.files[\"dem.png\"])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab07dbeb",
+   "metadata": {},
+   "source": [
+    "Reproject (warp) the DEM to another CRS (here WGS84 / EPSG:4326):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d6d2109",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = gl.run_tool(\n",
+    "    \"reproject_raster\",\n",
+    "    args=[\"--input=/work/dem.tif\", \"--epsg=4326\", \"--output=/work/dem_4326.tif\"],\n",
+    "    input={\"dem.tif\": dem},\n",
+    ")\n",
+    "print(res.stdout[-1])  # reports src_epsg, dst_epsg, rows, cols\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ccdcd266",
+   "metadata": {},
+   "source": [
+    "Slice the DEM into a Web Mercator XYZ PNG tile pyramid for web maps:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4bcbac63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = gl.run_tool(\n",
+    "    \"raster_to_tiles\",\n",
+    "    args=[\"--input=/work/dem.tif\", \"--output_dir=/work/tiles\",\n",
+    "          \"--min_zoom=10\", \"--max_zoom=12\", \"--colormap=terrain\"],\n",
+    "    input={\"dem.tif\": dem},\n",
+    ")\n",
+    "print(res.stdout[-1])\n",
+    "tiles = [k for k in res.files if k.endswith(\".png\")]\n",
+    "print(len(tiles), \"tiles, e.g.\", tiles[0])  # keys look like tiles/12/700/1635.png\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da3eb535",
+   "metadata": {},
+   "source": [
+    "## Vector: building footprints (GeoJSON, Shapefile, FlatGeobuf, GeoParquet, ...)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc93b337",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BLDG_URL = \"https://data.source.coop/giswqs/opengeos/las-vegas-buildings.geojson\"\n",
+    "buildings = fetch(BLDG_URL)\n",
+    "\n",
+    "# Convert to GeoParquet (Hilbert-sorted, bbox covering, ZSTD by default)\n",
+    "res = gl.run_tool(\n",
+    "    \"write_geoparquet\",\n",
+    "    args=[\"--input=/work/buildings.geojson\", \"--output=/work/buildings.parquet\"],\n",
+    "    input={\"buildings.geojson\": buildings},\n",
+    ")\n",
+    "print(res.stdout[-1])  # feature_count, compression, hilbert_sorted\n",
+    "open(\"las-vegas-buildings.parquet\", \"wb\").write(res.files[\"buildings.parquet\"])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf1c8986",
+   "metadata": {},
+   "source": [
+    "Add geometry attributes (area, perimeter, centroid, ...):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b7bac31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = gl.run_tool(\n",
+    "    \"add_geometry_attributes\",\n",
+    "    args=[\"--input=/work/buildings.geojson\", \"--area=true\", \"--perimeter=true\",\n",
+    "          \"--centroid=true\", \"--output=/work/buildings_attrs.geojson\"],\n",
+    "    input={\"buildings.geojson\": buildings},\n",
+    ")\n",
+    "print(res.exit_code, list(res.files))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07a154bf",
+   "metadata": {},
+   "source": [
+    "Read GeoParquet back to another vector format (driver from the extension):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70711844",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parquet = open(\"las-vegas-buildings.parquet\", \"rb\").read()\n",
+    "res = gl.run_tool(\n",
+    "    \"read_geoparquet\",\n",
+    "    args=[\"--input=/work/in.parquet\", \"--output=/work/out.fgb\"],  # FlatGeobuf\n",
+    "    input={\"in.parquet\": parquet},\n",
+    ")\n",
+    "print(res.stdout[-1])  # feature_count\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92e608f7",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "- `gl.list_tools()` returns every tool id (740+).\n",
+    "- `gl.list_manifests()` returns each tool's parameters and provenance\n",
+    "  (`\"source\": \"geolibre\" | \"whitebox\"`).\n",
+    "\n",
+    "```python\n",
+    "manifests = {m[\"id\"]: m for m in gl.list_manifests()}\n",
+    "manifests[\"slope\"][\"params\"]\n",
+    "```\n",
+    "\n",
+    "Docs: https://github.com/opengeos/geolibre-rust\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/npm/tools.mjs
+++ b/npm/tools.mjs
@@ -40,7 +40,10 @@ async function materializeInput(value) {
   if (typeof value === "string") {
     if (!/^https?:\/\//i.test(value))
       throw new Error(`input string must be an http(s) URL, got: ${value}`);
-    return new Uint8Array(await (await fetch(value)).arrayBuffer());
+    // A User-Agent helps with CDNs that reject non-browser agents (browsers
+    // ignore this header and send their own; Node/undici honors it).
+    const resp = await fetch(value, { headers: { "User-Agent": "Mozilla/5.0 (geolibre-wasm)" } });
+    return new Uint8Array(await resp.arrayBuffer());
   }
   return new Uint8Array(value);
 }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolibre-wasm"
-version = "0.4.2"
+version = "0.4.3"
 description = "Run the GeoLibre / whitebox_next_gen geospatial tool suite (WASM/WASI) from Python."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/geolibre_wasm/__init__.py
+++ b/python/src/geolibre_wasm/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "runtime_path",
 ]
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/python/src/geolibre_wasm/_core.py
+++ b/python/src/geolibre_wasm/_core.py
@@ -25,10 +25,20 @@ import wasmtime
 _WASM_MAGIC = b"\x00asm"
 #: Network timeout (seconds) for the one-time runtime download.
 _DOWNLOAD_TIMEOUT = 120
+#: Sent on HTTP fetches; some CDNs reject the default ``Python-urllib`` agent.
+_USER_AGENT = "Mozilla/5.0 (geolibre-wasm)"
+
+
+def _http_get(url: str, timeout: int) -> bytes:
+    """GET a URL to bytes with a browser-like User-Agent and a timeout."""
+    request = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+        return response.read()
+
 
 #: Release whose ``geolibre-cli.wasm`` asset this wrapper downloads by default.
 #: Kept in sync with the package version's ``vMAJOR.MINOR.PATCH`` tag.
-RUNTIME_VERSION = "v0.4.2"
+RUNTIME_VERSION = "v0.4.3"
 _ASSET = f"geolibre-cli-{RUNTIME_VERSION}.wasm"
 _RELEASE_URL = (
     "https://github.com/opengeos/geolibre-rust/releases/download/"
@@ -57,10 +67,7 @@ def _materialize_input(value: InputSource) -> bytes:
     if isinstance(value, (bytes, bytearray, memoryview)):
         return bytes(value)
     if isinstance(value, str) and value.startswith(("http://", "https://")):
-        with urllib.request.urlopen(  # noqa: S310 (caller-supplied URL)
-            value, timeout=_INPUT_TIMEOUT
-        ) as response:
-            return response.read()
+        return _http_get(value, _INPUT_TIMEOUT)
     if isinstance(value, (str, os.PathLike)):
         path = Path(value)
         if path.is_file():
@@ -116,10 +123,7 @@ def download_runtime(dest: Optional[PathLike] = None) -> str:
     """
     target = Path(dest) if dest is not None else _cache_path()
     target.parent.mkdir(parents=True, exist_ok=True)
-    with urllib.request.urlopen(  # noqa: S310 (trusted release URL)
-        _RELEASE_URL, timeout=_DOWNLOAD_TIMEOUT
-    ) as response:
-        data = response.read()
+    data = _http_get(_RELEASE_URL, _DOWNLOAD_TIMEOUT)
     # Guard against truncated or error-page downloads: every wasm module starts
     # with the "\0asm" magic.
     if not data.startswith(_WASM_MAGIC):


### PR DESCRIPTION
## Summary
- **Release v0.4.3.** Publishes the http(s) URL / local-path tool inputs (added in #13) and makes the URL fetch robust: send a browser `User-Agent` so CDNs that 403 the default agent (e.g. data.source.coop) work. Applied to the Python wrapper (`run_tool` URL inputs + the runtime download) and the JS `tools.mjs` fetch.
- **`examples/geolibre_wasm.ipynb`** - a runnable Colab quickstart over real public datasets (a DEM and Las Vegas building footprints from data.source.coop): slope, colormap PNG preview (inline), reproject, XYZ tiles, GeoJSON->GeoParquet, geometry attributes, GeoParquet roundtrip, plus a URL-input shortcut. Verified end to end (0 errors).
- **Colab badge** (top of README + Python section) and a **Recipes** section (vector, LiDAR point cloud, raster).
- Bump crates, npm, and the Python package to 0.4.3.

## Test plan
- [x] `nbconvert --execute` runs the whole notebook (incl. a live URL-input cell) with 0 errors
- [x] URL input verified from data.source.coop in both Python and JS (slope, 6.6 MB output)
- [x] `pytest python/tests` (5 passed); wheel + `twine check` pass; LICENSE bundled
- [ ] After merge: tag `v0.4.3` -> release publishes `geolibre-wasm@0.4.3` to npm + PyPI