### PR TITLE
feat: Tier A tools (spectral_index, vector_convert, render_vector_png, write_pmtiles)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,6 +735,7 @@ dependencies = [
 name = "geolibre-tools"
 version = "0.4.3"
 dependencies = [
+ "flate2",
  "parquet",
  "png 0.17.16",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -73,8 +73,12 @@ rendering tools that the whitebox suite lacks (all pure-Rust, running in WASM):
 | `reproject_raster` | Reproject (warp) a raster into a target EPSG CRS, with selectable resampling. |
 | `render_raster_png` | Render a raster band to a PNG through a colormap (viridis/magma/turbo/terrain/grayscale); no-data becomes transparent. |
 | `raster_to_tiles` | Slice a raster into a Web Mercator (EPSG:3857) XYZ PNG tile pyramid for web maps. |
+| `write_pmtiles` | Render a raster into a single PMTiles archive (the Web Mercator PNG pyramid as one file). |
+| `spectral_index` | Compute a spectral index (NDVI, NDWI, NDBI, NBR, EVI, SAVI) from a multi-band raster. |
 | `write_geoparquet` | Convert any supported vector format to GeoParquet, Hilbert-sorted with a bbox covering column and ZSTD compression by default. |
 | `read_geoparquet` | Read GeoParquet and convert it to another vector format (or store it in memory). |
+| `vector_convert` | Convert a vector dataset between formats (the output extension picks the driver). |
+| `render_vector_png` | Draw a vector layer (points/lines/polygons) to a PNG map image. |
 
 It also ships pure-Rust ports of the DEM depression/mount algorithms from
 [`opengeos/lidar`](https://github.com/opengeos/lidar) (no GDAL, RichDEM, SciPy,

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -23,3 +23,5 @@ serde_json = "1"
 # Pure-Rust PNG encoder (miniz_oxide backend), used by render_raster_png and
 # raster_to_tiles. Compiles cleanly to wasm32-wasip1.
 png = "0.17"
+# Pure-Rust gzip (miniz_oxide backend) for the PMTiles directory + metadata.
+flate2 = "1"

--- a/crates/geolibre-tools/src/common.rs
+++ b/crates/geolibre-tools/src/common.rs
@@ -127,3 +127,17 @@ pub fn raster_like_with_data(
     }
     Ok(out)
 }
+
+/// Writes raw bytes to a file path, creating parent directories as needed.
+/// Shared by the tools that emit non-raster artifacts (PNGs, tiles, archives).
+pub fn write_bytes(path: &str, bytes: &[u8]) -> Result<(), ToolError> {
+    if let Some(parent) = std::path::Path::new(path).parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                ToolError::Execution(format!("failed creating output directory: {e}"))
+            })?;
+        }
+    }
+    std::fs::write(path, bytes)
+        .map_err(|e| ToolError::Execution(format!("failed writing output file: {e}")))
+}

--- a/crates/geolibre-tools/src/hilbert.rs
+++ b/crates/geolibre-tools/src/hilbert.rs
@@ -19,7 +19,7 @@ pub fn xy_to_hilbert(x: u32, y: u32) -> u64 {
 /// Classic iterative xy->d Hilbert transform for an arbitrary grid `order`
 /// (grid is `2^order` per axis). Factored out so tests can exhaustively check a
 /// small grid.
-fn xy_to_hilbert_order(mut x: u32, mut y: u32, order: u32) -> u64 {
+pub(crate) fn xy_to_hilbert_order(mut x: u32, mut y: u32, order: u32) -> u64 {
     let n: u32 = 1 << order;
     let mut d: u64 = 0;
     let mut s: u32 = n / 2;

--- a/crates/geolibre-tools/src/lib.rs
+++ b/crates/geolibre-tools/src/lib.rs
@@ -16,13 +16,18 @@ mod fill;
 mod geoparquet_io;
 mod hilbert;
 mod polygonize;
+mod pmtiles;
 mod raster_normalize;
 mod raster_to_tiles;
 mod regions;
 mod render;
 mod render_png;
+mod render_vector_png;
 mod reproject_raster;
+mod spectral_index;
 mod vector_common;
+mod vector_convert;
+mod write_pmtiles;
 
 use wbcore::Tool;
 
@@ -50,6 +55,10 @@ pub fn geolibre_tools() -> Vec<Box<dyn Tool>> {
         Box::new(raster_to_tiles::RasterToTilesTool),
         Box::new(geoparquet_io::WriteGeoParquetTool),
         Box::new(geoparquet_io::ReadGeoParquetTool),
+        Box::new(spectral_index::SpectralIndexTool),
+        Box::new(vector_convert::VectorConvertTool),
+        Box::new(render_vector_png::RenderVectorPngTool),
+        Box::new(write_pmtiles::WritePmTilesTool),
     ]
 }
 

--- a/crates/geolibre-tools/src/pmtiles.rs
+++ b/crates/geolibre-tools/src/pmtiles.rs
@@ -1,0 +1,290 @@
+//! Minimal PMTiles v3 archive writer for PNG raster tiles.
+//!
+//! Implements just enough of the PMTiles v3 spec to pack a set of `(z, x, y)`
+//! PNG tiles into a single clustered archive: a gzip-compressed root directory,
+//! gzip-compressed JSON metadata, and the concatenated (deduplicated) tile data.
+//! Spec: <https://github.com/protomaps/PMTiles/blob/main/spec/v3/spec.md>.
+
+use std::collections::HashMap;
+use std::io::Write;
+
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use wbcore::ToolError;
+
+const HEADER_LEN: usize = 127;
+const TILETYPE_PNG: u8 = 2;
+const COMPRESSION_NONE: u8 = 1;
+const COMPRESSION_GZIP: u8 = 2;
+
+/// One tile to include in the archive.
+pub struct Tile {
+    pub z: u8,
+    pub x: u32,
+    pub y: u32,
+    pub data: Vec<u8>,
+}
+
+/// Geographic bounds (degrees) for the header.
+pub struct LonLatBounds {
+    pub min_lon: f64,
+    pub min_lat: f64,
+    pub max_lon: f64,
+    pub max_lat: f64,
+}
+
+struct Entry {
+    tile_id: u64,
+    offset: u64,
+    length: u32,
+    run_length: u32,
+}
+
+/// Builds a complete PMTiles v3 archive from PNG tiles.
+///
+/// `tiles` need not be sorted. Identical tile blobs are deduplicated. The whole
+/// directory is stored in the header's root directory (no leaf directories),
+/// which is fine for the bounded pyramids this crate produces.
+pub fn build(
+    mut tiles: Vec<Tile>,
+    bounds: &LonLatBounds,
+    min_zoom: u8,
+    max_zoom: u8,
+) -> Result<Vec<u8>, ToolError> {
+    // Address each tile by its PMTiles (Hilbert) tile id and sort ascending.
+    tiles.sort_by_key(|t| zxy_to_tile_id(t.z, t.x, t.y));
+
+    // Concatenate tile data, deduplicating identical blobs by content.
+    let mut tile_data: Vec<u8> = Vec::new();
+    let mut seen: HashMap<Vec<u8>, (u64, u32)> = HashMap::new();
+    let mut entries: Vec<Entry> = Vec::with_capacity(tiles.len());
+    for t in &tiles {
+        let (offset, length) = match seen.get(&t.data) {
+            Some(&(off, len)) => (off, len),
+            None => {
+                let off = tile_data.len() as u64;
+                let len = t.data.len() as u32;
+                tile_data.extend_from_slice(&t.data);
+                seen.insert(t.data.clone(), (off, len));
+                (off, len)
+            }
+        };
+        entries.push(Entry {
+            tile_id: zxy_to_tile_id(t.z, t.x, t.y),
+            offset,
+            length,
+            run_length: 1,
+        });
+    }
+
+    let root_dir = gzip(&serialize_directory(&entries))?;
+    let metadata = gzip(br#"{"type":"overlay","format":"png"}"#)?;
+
+    let root_dir_offset = HEADER_LEN as u64;
+    let root_dir_length = root_dir.len() as u64;
+    let metadata_offset = root_dir_offset + root_dir_length;
+    let metadata_length = metadata.len() as u64;
+    let leaf_dirs_offset = metadata_offset + metadata_length;
+    let tile_data_offset = leaf_dirs_offset; // no leaf directories
+    let tile_data_length = tile_data.len() as u64;
+
+    let header = build_header(
+        root_dir_offset,
+        root_dir_length,
+        metadata_offset,
+        metadata_length,
+        leaf_dirs_offset,
+        0,
+        tile_data_offset,
+        tile_data_length,
+        tiles.len() as u64,
+        entries.len() as u64,
+        seen.len() as u64,
+        min_zoom,
+        max_zoom,
+        bounds,
+    );
+
+    let mut out = Vec::with_capacity(
+        HEADER_LEN + root_dir.len() + metadata.len() + tile_data.len(),
+    );
+    out.extend_from_slice(&header);
+    out.extend_from_slice(&root_dir);
+    out.extend_from_slice(&metadata);
+    out.extend_from_slice(&tile_data);
+    Ok(out)
+}
+
+/// PMTiles tile id for a `(z, x, y)` tile: the per-zoom base offset plus the
+/// Hilbert-curve distance within the zoom. Mirrors the spec's reference
+/// `zxyToTileId` exactly (note `s - 1 - x`, signed).
+fn zxy_to_tile_id(z: u8, x: u32, y: u32) -> u64 {
+    let mut acc: u64 = 0;
+    for t in 0..z {
+        let dim = 1i64 << t;
+        acc += (dim * dim) as u64;
+    }
+    let n = 1i64 << z;
+    let (mut xx, mut yy) = (x as i64, y as i64);
+    let mut d: i64 = 0;
+    let mut s = n / 2;
+    while s > 0 {
+        let rx = i64::from((xx & s) > 0);
+        let ry = i64::from((yy & s) > 0);
+        d += s * s * ((3 * rx) ^ ry);
+        if ry == 0 {
+            if rx == 1 {
+                xx = s - 1 - xx;
+                yy = s - 1 - yy;
+            }
+            std::mem::swap(&mut xx, &mut yy);
+        }
+        s /= 2;
+    }
+    acc + d as u64
+}
+
+/// Serializes directory entries (sorted by tile id) per the v3 spec: counts and
+/// columns of varints with run-length / clustered-offset encoding.
+fn serialize_directory(entries: &[Entry]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    write_uvarint(&mut buf, entries.len() as u64);
+
+    let mut last_id = 0u64;
+    for e in entries {
+        write_uvarint(&mut buf, e.tile_id - last_id);
+        last_id = e.tile_id;
+    }
+    for e in entries {
+        write_uvarint(&mut buf, e.run_length as u64);
+    }
+    for e in entries {
+        write_uvarint(&mut buf, e.length as u64);
+    }
+    for (i, e) in entries.iter().enumerate() {
+        if i > 0 && e.offset == entries[i - 1].offset + entries[i - 1].length as u64 {
+            write_uvarint(&mut buf, 0);
+        } else {
+            write_uvarint(&mut buf, e.offset + 1);
+        }
+    }
+    buf
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_header(
+    root_dir_offset: u64,
+    root_dir_length: u64,
+    metadata_offset: u64,
+    metadata_length: u64,
+    leaf_dirs_offset: u64,
+    leaf_dirs_length: u64,
+    tile_data_offset: u64,
+    tile_data_length: u64,
+    num_addressed_tiles: u64,
+    num_tile_entries: u64,
+    num_tile_contents: u64,
+    min_zoom: u8,
+    max_zoom: u8,
+    b: &LonLatBounds,
+) -> [u8; HEADER_LEN] {
+    let mut h = [0u8; HEADER_LEN];
+    h[0..7].copy_from_slice(b"PMTiles");
+    h[7] = 3; // version
+    let put = |h: &mut [u8; HEADER_LEN], at: usize, v: u64| {
+        h[at..at + 8].copy_from_slice(&v.to_le_bytes());
+    };
+    put(&mut h, 8, root_dir_offset);
+    put(&mut h, 16, root_dir_length);
+    put(&mut h, 24, metadata_offset);
+    put(&mut h, 32, metadata_length);
+    put(&mut h, 40, leaf_dirs_offset);
+    put(&mut h, 48, leaf_dirs_length);
+    put(&mut h, 56, tile_data_offset);
+    put(&mut h, 64, tile_data_length);
+    put(&mut h, 72, num_addressed_tiles);
+    put(&mut h, 80, num_tile_entries);
+    put(&mut h, 88, num_tile_contents);
+    h[96] = 1; // clustered
+    h[97] = COMPRESSION_GZIP; // internal compression (directories + metadata)
+    h[98] = COMPRESSION_NONE; // tile compression (PNG is already compressed)
+    h[99] = TILETYPE_PNG;
+    h[100] = min_zoom;
+    h[101] = max_zoom;
+    let e7 = |deg: f64| (deg * 1e7).round() as i32;
+    let put_i32 = |h: &mut [u8; HEADER_LEN], at: usize, v: i32| {
+        h[at..at + 4].copy_from_slice(&v.to_le_bytes());
+    };
+    put_i32(&mut h, 102, e7(b.min_lon));
+    put_i32(&mut h, 106, e7(b.min_lat));
+    put_i32(&mut h, 110, e7(b.max_lon));
+    put_i32(&mut h, 114, e7(b.max_lat));
+    h[118] = min_zoom; // center zoom
+    put_i32(&mut h, 119, e7((b.min_lon + b.max_lon) / 2.0));
+    put_i32(&mut h, 123, e7((b.min_lat + b.max_lat) / 2.0));
+    h
+}
+
+fn gzip(data: &[u8]) -> Result<Vec<u8>, ToolError> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(data)
+        .and_then(|_| encoder.finish())
+        .map_err(|e| ToolError::Execution(format!("gzip failed: {e}")))
+}
+
+/// Unsigned LEB128 varint.
+fn write_uvarint(buf: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        buf.push(byte);
+        if value == 0 {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tile_ids_match_pmtiles_spec() {
+        // Known values from the PMTiles v3 reference.
+        assert_eq!(zxy_to_tile_id(0, 0, 0), 0);
+        assert_eq!(zxy_to_tile_id(1, 0, 0), 1);
+        assert_eq!(zxy_to_tile_id(1, 0, 1), 2);
+        assert_eq!(zxy_to_tile_id(1, 1, 1), 3);
+        assert_eq!(zxy_to_tile_id(1, 1, 0), 4);
+        assert_eq!(zxy_to_tile_id(2, 0, 0), 5);
+    }
+
+    #[test]
+    fn varint_roundtrips_small_and_large() {
+        let mut b = Vec::new();
+        write_uvarint(&mut b, 0);
+        write_uvarint(&mut b, 127);
+        write_uvarint(&mut b, 128);
+        write_uvarint(&mut b, 300);
+        assert_eq!(b, vec![0x00, 0x7f, 0x80, 0x01, 0xac, 0x02]);
+    }
+
+    #[test]
+    fn build_emits_a_valid_header() {
+        let tiles = vec![
+            Tile { z: 1, x: 0, y: 0, data: vec![1, 2, 3] },
+            Tile { z: 1, x: 1, y: 1, data: vec![1, 2, 3] }, // dup content
+        ];
+        let bounds = LonLatBounds { min_lon: -10.0, min_lat: -5.0, max_lon: 10.0, max_lat: 5.0 };
+        let archive = build(tiles, &bounds, 1, 1).unwrap();
+        assert_eq!(&archive[0..7], b"PMTiles");
+        assert_eq!(archive[7], 3);
+        assert_eq!(archive[99], TILETYPE_PNG);
+        // num_tile_contents (offset 88) is 1 (the two tiles share one blob).
+        assert_eq!(u64::from_le_bytes(archive[88..96].try_into().unwrap()), 1);
+    }
+}

--- a/crates/geolibre-tools/src/raster_to_tiles.rs
+++ b/crates/geolibre-tools/src/raster_to_tiles.rs
@@ -19,11 +19,11 @@ use crate::render::{encode_png_rgba, normalize, Colormap};
 use crate::reproject_raster::parse_resample;
 
 /// EPSG:3857 (Web Mercator) world half-extent in meters: pi * 6378137.
-const ORIGIN: f64 = 20_037_508.342_789_244;
-const TILE_SIZE: usize = 256;
-const WEB_MERCATOR_EPSG: u32 = 3857;
+pub(crate) const ORIGIN: f64 = 20_037_508.342_789_244;
+pub(crate) const TILE_SIZE: usize = 256;
+pub(crate) const WEB_MERCATOR_EPSG: u32 = 3857;
 /// Safety cap so a too-wide zoom range cannot generate an unbounded pyramid.
-const MAX_TILES: usize = 4096;
+pub(crate) const MAX_TILES: usize = 4096;
 
 /// Renders a raster into a Web Mercator XYZ PNG tile pyramid.
 pub struct RasterToTilesTool;
@@ -240,7 +240,7 @@ impl Tool for RasterToTilesTool {
 /// Renders one 256x256 tile. Returns `None` if every pixel is no-data / outside
 /// the raster, so the caller can skip writing an empty tile.
 #[allow(clippy::too_many_arguments)]
-fn render_tile(
+pub(crate) fn render_tile(
     merc: &Raster,
     band: isize,
     x0: f64,
@@ -277,7 +277,7 @@ fn render_tile(
 
 /// Inclusive tile-index range covering `[lo, hi]` along an axis whose tile 0
 /// starts at `axis_origin`, with `span`-meter tiles and `n` tiles total.
-fn tile_range(lo: f64, hi: f64, axis_origin: f64, span: f64, n: u64) -> (u64, u64) {
+pub(crate) fn tile_range(lo: f64, hi: f64, axis_origin: f64, span: f64, n: u64) -> (u64, u64) {
     let max_idx = n - 1;
     let a = (((lo - axis_origin) / span).floor()).clamp(0.0, max_idx as f64) as u64;
     // Subtract a tiny epsilon so a coordinate exactly on a tile boundary does
@@ -287,7 +287,7 @@ fn tile_range(lo: f64, hi: f64, axis_origin: f64, span: f64, n: u64) -> (u64, u6
 }
 
 /// Zoom level whose 256px tiles have a pixel size closest to `cell_size_m`.
-fn native_zoom(cell_size_m: f64) -> u32 {
+pub(crate) fn native_zoom(cell_size_m: f64) -> u32 {
     if cell_size_m <= 0.0 {
         return 0;
     }

--- a/crates/geolibre-tools/src/raster_to_tiles.rs
+++ b/crates/geolibre-tools/src/raster_to_tiles.rs
@@ -5,8 +5,6 @@
 //! tile grid into 256x256 RGBA PNGs written as `{output_dir}/{z}/{x}/{y}.png`.
 //! Fully transparent (no-data) tiles are skipped so the pyramid stays sparse.
 
-use std::path::Path;
-
 use serde_json::{json, Value};
 use wbcore::{
     LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata,
@@ -14,7 +12,7 @@ use wbcore::{
 };
 use wbraster::{NodataPolicy, Raster, ResampleMethod};
 
-use crate::common::load_input_raster;
+use crate::common::{load_input_raster, write_bytes};
 use crate::render::{encode_png_rgba, normalize, Colormap};
 use crate::reproject_raster::parse_resample;
 
@@ -294,17 +292,4 @@ pub(crate) fn native_zoom(cell_size_m: f64) -> u32 {
     // res(z) = (2*ORIGIN) / (256 * 2^z); solve for z so res ~= cell_size_m.
     let z = ((2.0 * ORIGIN / (TILE_SIZE as f64 * cell_size_m)).log2()).round();
     z.clamp(0.0, 24.0) as u32
-}
-
-/// Writes bytes to a path, creating parent directories as needed.
-fn write_bytes(path: &str, bytes: &[u8]) -> Result<(), ToolError> {
-    if let Some(parent) = Path::new(path).parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent).map_err(|e| {
-                ToolError::Execution(format!("failed creating tile directory: {e}"))
-            })?;
-        }
-    }
-    std::fs::write(path, bytes)
-        .map_err(|e| ToolError::Execution(format!("failed writing tile: {e}")))
 }

--- a/crates/geolibre-tools/src/render_vector_png.rs
+++ b/crates/geolibre-tools/src/render_vector_png.rs
@@ -5,8 +5,6 @@
 //! (e.g. in a notebook) without a mapping library. Single fill/stroke colors;
 //! the image aspect ratio follows the data unless a height is given.
 
-use std::path::Path;
-
 use serde_json::{json, Value};
 use wbcore::{
     LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata,
@@ -14,6 +12,7 @@ use wbcore::{
 };
 use wbvector::{Coord, Geometry, Ring};
 
+use crate::common::write_bytes;
 use crate::render::encode_png_rgba;
 use crate::vector_common::load_input_layer;
 
@@ -272,9 +271,17 @@ fn fill_rings(canvas: &mut Canvas, rings: &[Vec<(f64, f64)>], fill: Rgba) {
         let yc = y as f64 + 0.5;
         let mut xs: Vec<f64> = Vec::new();
         for ring in rings {
-            for seg in ring.windows(2) {
-                let (x0, ya) = seg[0];
-                let (x1, yb) = seg[1];
+            let len = ring.len();
+            if len < 2 {
+                continue;
+            }
+            // Iterate every edge including the closing one (`(i + 1) % len`) so a
+            // ring that does not repeat its first vertex still fills correctly;
+            // a ring that does repeat it just yields a degenerate (no-crossing)
+            // closing edge.
+            for i in 0..len {
+                let (x0, ya) = ring[i];
+                let (x1, yb) = ring[(i + 1) % len];
                 // Half-open edge test avoids double-counting shared vertices.
                 if (ya <= yc && yb > yc) || (yb <= yc && ya > yc) {
                     let t = (yc - ya) / (yb - ya);
@@ -357,6 +364,11 @@ fn parse_color(s: &str) -> Result<Rgba, ToolError> {
         return Ok([0, 0, 0, 0]);
     }
     let hex = s.strip_prefix('#').unwrap_or(s);
+    // Guard before byte-slicing: a multi-byte char could otherwise make a 6/8
+    // byte string slice across a char boundary and panic.
+    if !hex.is_ascii() {
+        return Err(color_err(s));
+    }
     let byte = |i: usize| u8::from_str_radix(&hex[i..i + 2], 16).ok();
     match hex.len() {
         6 => match (byte(0), byte(2), byte(4)) {
@@ -382,16 +394,4 @@ fn require_str<'a>(args: &'a ToolArgs, key: &str) -> Result<&'a str, ToolError> 
         .and_then(Value::as_str)
         .filter(|s| !s.trim().is_empty())
         .ok_or_else(|| ToolError::Validation(format!("missing required string parameter '{key}'")))
-}
-
-fn write_bytes(path: &str, bytes: &[u8]) -> Result<(), ToolError> {
-    if let Some(parent) = Path::new(path).parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent).map_err(|e| {
-                ToolError::Execution(format!("failed creating output directory: {e}"))
-            })?;
-        }
-    }
-    std::fs::write(path, bytes)
-        .map_err(|e| ToolError::Execution(format!("failed writing output file: {e}")))
 }

--- a/crates/geolibre-tools/src/render_vector_png.rs
+++ b/crates/geolibre-tools/src/render_vector_png.rs
@@ -1,0 +1,397 @@
+//! GeoLibre tool: draw a vector layer to a PNG map image.
+//!
+//! The vector analog of `render_raster_png`: rasterize points, lines, and
+//! polygons (with holes) to an RGBA PNG so a layer can be previewed inline
+//! (e.g. in a notebook) without a mapping library. Single fill/stroke colors;
+//! the image aspect ratio follows the data unless a height is given.
+
+use std::path::Path;
+
+use serde_json::{json, Value};
+use wbcore::{
+    LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata,
+    ToolParamSpec, ToolRunResult,
+};
+use wbvector::{Coord, Geometry, Ring};
+
+use crate::render::encode_png_rgba;
+use crate::vector_common::load_input_layer;
+
+type Rgba = [u8; 4];
+
+/// Renders a vector layer to an RGBA PNG.
+pub struct RenderVectorPngTool;
+
+impl Tool for RenderVectorPngTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "render_vector_png",
+            display_name: "Render Vector to PNG",
+            summary: "Draw a vector layer (points/lines/polygons) to a PNG map image.",
+            category: ToolCategory::Vector,
+            license_tier: LicenseTier::Open,
+            params: vec![
+                ToolParamSpec { name: "input", description: "Input vector file path or in-memory handle.", required: true },
+                ToolParamSpec { name: "output", description: "Output PNG file path (e.g. /work/map.png).", required: true },
+                ToolParamSpec { name: "width", description: "Image width in pixels (default 800).", required: false },
+                ToolParamSpec { name: "height", description: "Image height in pixels (default: from the data aspect ratio).", required: false },
+                ToolParamSpec { name: "fill", description: "Polygon/point fill color as #rrggbb or #rrggbbaa (default semi-transparent blue).", required: false },
+                ToolParamSpec { name: "stroke", description: "Outline/line color as #rrggbb or #rrggbbaa (default dark blue).", required: false },
+                ToolParamSpec { name: "stroke_width", description: "Outline/line width in pixels (default 1).", required: false },
+                ToolParamSpec { name: "background", description: "Background color as #rrggbb[aa] or 'transparent' (default transparent).", required: false },
+            ],
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        for key in ["input", "output"] {
+            if args.get(key).and_then(Value::as_str).is_none() {
+                return Err(ToolError::Validation(format!(
+                    "missing required string parameter '{key}'"
+                )));
+            }
+        }
+        for key in ["fill", "stroke", "background"] {
+            if let Some(c) = args.get(key).and_then(Value::as_str) {
+                parse_color(c)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = require_str(args, "input")?;
+        let output = require_str(args, "output")?;
+        let fill = color_or(args, "fill", [51, 136, 255, 150])?;
+        let stroke = color_or(args, "stroke", [20, 60, 120, 255])?;
+        let background = color_or(args, "background", [0, 0, 0, 0])?;
+        let stroke_width = args.get("stroke_width").and_then(Value::as_u64).unwrap_or(1).max(1) as i64;
+        let width = args.get("width").and_then(Value::as_u64).unwrap_or(800).clamp(16, 8192) as i64;
+        let pad: f64 = 8.0;
+
+        let layer = load_input_layer(input)?;
+        let extent = layer_extent(&layer)
+            .ok_or_else(|| ToolError::Execution("layer has no drawable geometry".to_string()))?;
+        let (min_x, min_y, max_x, max_y) = extent;
+
+        // Height follows the data aspect ratio unless overridden.
+        let span_x = (max_x - min_x).max(f64::MIN_POSITIVE);
+        let span_y = (max_y - min_y).max(f64::MIN_POSITIVE);
+        let height = match args.get("height").and_then(Value::as_u64) {
+            Some(h) => (h as i64).clamp(16, 8192),
+            None => {
+                let inner_w = (width as f64 - 2.0 * pad).max(1.0);
+                let h = inner_w * span_y / span_x + 2.0 * pad;
+                (h.round() as i64).clamp(16, 8192)
+            }
+        };
+
+        let inner_w = width as f64 - 2.0 * pad;
+        let inner_h = height as f64 - 2.0 * pad;
+        // World -> pixel. Y is flipped (north up). Degenerate spans center the data.
+        let to_px = |c: &Coord| -> (f64, f64) {
+            let fx = if max_x > min_x { (c.x - min_x) / span_x } else { 0.5 };
+            let fy = if max_y > min_y { (max_y - c.y) / span_y } else { 0.5 };
+            (pad + fx * inner_w, pad + fy * inner_h)
+        };
+
+        ctx.progress.info("rasterizing features");
+        let mut canvas = Canvas::new(width, height, background);
+        for feature in &layer.features {
+            if let Some(geom) = &feature.geometry {
+                draw_geometry(&mut canvas, geom, &to_px, fill, stroke, stroke_width);
+            }
+        }
+
+        let png = encode_png_rgba(&canvas.rgba, width as u32, height as u32)?;
+        write_bytes(output, &png)?;
+
+        let mut outputs = std::collections::BTreeMap::new();
+        outputs.insert("output".to_string(), json!(output));
+        outputs.insert("width".to_string(), json!(width));
+        outputs.insert("height".to_string(), json!(height));
+        outputs.insert("feature_count".to_string(), json!(layer.features.len()));
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+/// A simple RGBA8 raster canvas with straight-alpha "source over" compositing.
+struct Canvas {
+    w: i64,
+    h: i64,
+    rgba: Vec<u8>,
+}
+
+impl Canvas {
+    fn new(w: i64, h: i64, background: Rgba) -> Self {
+        let mut rgba = vec![0u8; (w * h * 4) as usize];
+        if background[3] != 0 {
+            for px in rgba.chunks_exact_mut(4) {
+                px.copy_from_slice(&background);
+            }
+        }
+        Self { w, h, rgba }
+    }
+
+    fn blend(&mut self, x: i64, y: i64, c: Rgba) {
+        if x < 0 || y < 0 || x >= self.w || y >= self.h || c[3] == 0 {
+            return;
+        }
+        let i = ((y * self.w + x) * 4) as usize;
+        let sa = c[3] as f64 / 255.0;
+        let da = self.rgba[i + 3] as f64 / 255.0;
+        let out_a = sa + da * (1.0 - sa);
+        for ch in 0..3 {
+            let s = c[ch] as f64;
+            let d = self.rgba[i + ch] as f64;
+            let v = if out_a > 0.0 {
+                (s * sa + d * da * (1.0 - sa)) / out_a
+            } else {
+                0.0
+            };
+            self.rgba[i + ch] = v.round().clamp(0.0, 255.0) as u8;
+        }
+        self.rgba[i + 3] = (out_a * 255.0).round().clamp(0.0, 255.0) as u8;
+    }
+
+    /// Fills a square of side `2*r+1` centered at `(x, y)` (used to thicken
+    /// lines and draw points).
+    fn dot(&mut self, x: i64, y: i64, r: i64, c: Rgba) {
+        for dy in -r..=r {
+            for dx in -r..=r {
+                self.blend(x + dx, y + dy, c);
+            }
+        }
+    }
+}
+
+/// Recursively draws a geometry: polygons are filled (even-odd, holes honored)
+/// then outlined; lines are stroked; points are dots.
+fn draw_geometry<F: Fn(&Coord) -> (f64, f64)>(
+    canvas: &mut Canvas,
+    geom: &Geometry,
+    to_px: &F,
+    fill: Rgba,
+    stroke: Rgba,
+    sw: i64,
+) {
+    match geom {
+        Geometry::Point(c) => {
+            let (x, y) = to_px(c);
+            canvas.dot(x.round() as i64, y.round() as i64, sw.max(2), fill);
+        }
+        Geometry::MultiPoint(cs) => {
+            for c in cs {
+                let (x, y) = to_px(c);
+                canvas.dot(x.round() as i64, y.round() as i64, sw.max(2), fill);
+            }
+        }
+        Geometry::LineString(cs) => draw_line_string(canvas, cs, to_px, stroke, sw),
+        Geometry::MultiLineString(lines) => {
+            for cs in lines {
+                draw_line_string(canvas, cs, to_px, stroke, sw);
+            }
+        }
+        Geometry::Polygon { exterior, interiors } => {
+            draw_polygon(canvas, exterior, interiors, to_px, fill, stroke, sw)
+        }
+        Geometry::MultiPolygon(polys) => {
+            for (exterior, interiors) in polys {
+                draw_polygon(canvas, exterior, interiors, to_px, fill, stroke, sw);
+            }
+        }
+        Geometry::GeometryCollection(gs) => {
+            for g in gs {
+                draw_geometry(canvas, g, to_px, fill, stroke, sw);
+            }
+        }
+    }
+}
+
+fn draw_line_string<F: Fn(&Coord) -> (f64, f64)>(
+    canvas: &mut Canvas,
+    coords: &[Coord],
+    to_px: &F,
+    stroke: Rgba,
+    sw: i64,
+) {
+    let pts: Vec<(f64, f64)> = coords.iter().map(to_px).collect();
+    for seg in pts.windows(2) {
+        draw_segment(canvas, seg[0], seg[1], stroke, sw);
+    }
+}
+
+fn draw_polygon<F: Fn(&Coord) -> (f64, f64)>(
+    canvas: &mut Canvas,
+    exterior: &Ring,
+    interiors: &[Ring],
+    to_px: &F,
+    fill: Rgba,
+    stroke: Rgba,
+    sw: i64,
+) {
+    // Even-odd scanline fill over the exterior plus all interior rings; an
+    // even number of crossings inside a hole flips back to "outside", so holes
+    // are honored automatically.
+    let rings: Vec<Vec<(f64, f64)>> = std::iter::once(exterior)
+        .chain(interiors)
+        .map(|r| r.coords().iter().map(to_px).collect())
+        .collect();
+    if fill[3] != 0 {
+        fill_rings(canvas, &rings, fill);
+    }
+    for ring in &rings {
+        for seg in ring.windows(2) {
+            draw_segment(canvas, seg[0], seg[1], stroke, sw);
+        }
+        // Close the ring if the data did not repeat the first vertex.
+        if let (Some(&first), Some(&last)) = (ring.first(), ring.last()) {
+            if first != last {
+                draw_segment(canvas, last, first, stroke, sw);
+            }
+        }
+    }
+}
+
+/// Even-odd polygon fill across all rings.
+fn fill_rings(canvas: &mut Canvas, rings: &[Vec<(f64, f64)>], fill: Rgba) {
+    let mut y_min = f64::INFINITY;
+    let mut y_max = f64::NEG_INFINITY;
+    for ring in rings {
+        for &(_, y) in ring {
+            y_min = y_min.min(y);
+            y_max = y_max.max(y);
+        }
+    }
+    if !y_min.is_finite() {
+        return;
+    }
+    let y0 = (y_min.floor() as i64).max(0);
+    let y1 = (y_max.ceil() as i64).min(canvas.h - 1);
+    for y in y0..=y1 {
+        let yc = y as f64 + 0.5;
+        let mut xs: Vec<f64> = Vec::new();
+        for ring in rings {
+            for seg in ring.windows(2) {
+                let (x0, ya) = seg[0];
+                let (x1, yb) = seg[1];
+                // Half-open edge test avoids double-counting shared vertices.
+                if (ya <= yc && yb > yc) || (yb <= yc && ya > yc) {
+                    let t = (yc - ya) / (yb - ya);
+                    xs.push(x0 + t * (x1 - x0));
+                }
+            }
+        }
+        xs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let mut i = 0;
+        while i + 1 < xs.len() {
+            let xa = xs[i].round() as i64;
+            let xb = xs[i + 1].round() as i64;
+            for x in xa..xb {
+                canvas.blend(x, y, fill);
+            }
+            i += 2;
+        }
+    }
+}
+
+/// Bresenham line between two pixel points, thickened to `sw` pixels.
+fn draw_segment(canvas: &mut Canvas, a: (f64, f64), b: (f64, f64), c: Rgba, sw: i64) {
+    let r = (sw - 1).max(0) / 2;
+    let (mut x0, mut y0) = (a.0.round() as i64, a.1.round() as i64);
+    let (x1, y1) = (b.0.round() as i64, b.1.round() as i64);
+    let dx = (x1 - x0).abs();
+    let dy = -(y1 - y0).abs();
+    let sx = if x0 < x1 { 1 } else { -1 };
+    let sy = if y0 < y1 { 1 } else { -1 };
+    let mut err = dx + dy;
+    loop {
+        if r == 0 {
+            canvas.blend(x0, y0, c);
+        } else {
+            canvas.dot(x0, y0, r, c);
+        }
+        if x0 == x1 && y0 == y1 {
+            break;
+        }
+        let e2 = 2 * err;
+        if e2 >= dy {
+            err += dy;
+            x0 += sx;
+        }
+        if e2 <= dx {
+            err += dx;
+            y0 += sy;
+        }
+    }
+}
+
+/// Bounding box over every feature geometry: `(min_x, min_y, max_x, max_y)`.
+fn layer_extent(layer: &wbvector::Layer) -> Option<(f64, f64, f64, f64)> {
+    let (mut min_x, mut min_y, mut max_x, mut max_y) =
+        (f64::INFINITY, f64::INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY);
+    let mut any = false;
+    for f in &layer.features {
+        if let Some(b) = f.geometry.as_ref().and_then(|g| g.bbox()) {
+            min_x = min_x.min(b.min_x);
+            min_y = min_y.min(b.min_y);
+            max_x = max_x.max(b.max_x);
+            max_y = max_y.max(b.max_y);
+            any = true;
+        }
+    }
+    any.then_some((min_x, min_y, max_x, max_y))
+}
+
+fn color_or(args: &ToolArgs, key: &str, default: Rgba) -> Result<Rgba, ToolError> {
+    match args.get(key).and_then(Value::as_str) {
+        Some(c) => parse_color(c),
+        None => Ok(default),
+    }
+}
+
+/// Parses `#rrggbb`, `#rrggbbaa`, or `transparent`/`none` into RGBA.
+fn parse_color(s: &str) -> Result<Rgba, ToolError> {
+    let s = s.trim();
+    if s.eq_ignore_ascii_case("transparent") || s.eq_ignore_ascii_case("none") {
+        return Ok([0, 0, 0, 0]);
+    }
+    let hex = s.strip_prefix('#').unwrap_or(s);
+    let byte = |i: usize| u8::from_str_radix(&hex[i..i + 2], 16).ok();
+    match hex.len() {
+        6 => match (byte(0), byte(2), byte(4)) {
+            (Some(r), Some(g), Some(b)) => Ok([r, g, b, 255]),
+            _ => Err(color_err(s)),
+        },
+        8 => match (byte(0), byte(2), byte(4), byte(6)) {
+            (Some(r), Some(g), Some(b), Some(a)) => Ok([r, g, b, a]),
+            _ => Err(color_err(s)),
+        },
+        _ => Err(color_err(s)),
+    }
+}
+
+fn color_err(s: &str) -> ToolError {
+    ToolError::Validation(format!(
+        "invalid color '{s}' (expected #rrggbb, #rrggbbaa, or transparent)"
+    ))
+}
+
+fn require_str<'a>(args: &'a ToolArgs, key: &str) -> Result<&'a str, ToolError> {
+    args.get(key)
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| ToolError::Validation(format!("missing required string parameter '{key}'")))
+}
+
+fn write_bytes(path: &str, bytes: &[u8]) -> Result<(), ToolError> {
+    if let Some(parent) = Path::new(path).parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                ToolError::Execution(format!("failed creating output directory: {e}"))
+            })?;
+        }
+    }
+    std::fs::write(path, bytes)
+        .map_err(|e| ToolError::Execution(format!("failed writing output file: {e}")))
+}

--- a/crates/geolibre-tools/src/spectral_index.rs
+++ b/crates/geolibre-tools/src/spectral_index.rs
@@ -1,0 +1,216 @@
+//! GeoLibre tool: compute a named spectral index from a multi-band raster.
+//!
+//! The whitebox suite ships a few hardcoded derived products but no general
+//! index calculator. This computes NDVI / NDWI / NDBI / NBR / EVI / SAVI from
+//! band numbers the caller maps to red / nir / green / blue / swir.
+
+use serde_json::{json, Value};
+use wbcore::{
+    LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata,
+    ToolParamSpec, ToolRunResult,
+};
+use wbraster::DataType;
+
+use crate::common::{load_input_raster, parse_optional_output, raster_like_with_data, write_or_store_output};
+
+/// Nodata value written for cells where any required band is nodata.
+const INDEX_NODATA: f64 = -9999.0;
+
+/// Which sensor band each index needs (1-based band numbers from the input).
+#[derive(Clone, Copy)]
+enum Index {
+    Ndvi,
+    Ndwi,
+    Ndbi,
+    Nbr,
+    Evi,
+    Savi,
+}
+
+impl Index {
+    fn parse(name: &str) -> Result<Self, ToolError> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "ndvi" => Ok(Self::Ndvi),
+            "ndwi" => Ok(Self::Ndwi),
+            "ndbi" => Ok(Self::Ndbi),
+            "nbr" => Ok(Self::Nbr),
+            "evi" => Ok(Self::Evi),
+            "savi" => Ok(Self::Savi),
+            other => Err(ToolError::Validation(format!(
+                "unknown index '{other}' (expected ndvi, ndwi, ndbi, nbr, evi, or savi)"
+            ))),
+        }
+    }
+}
+
+/// Computes a normalized or enhanced vegetation/water/built-up index.
+pub struct SpectralIndexTool;
+
+impl Tool for SpectralIndexTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "spectral_index",
+            display_name: "Spectral Index",
+            summary: "Compute a spectral index (NDVI, NDWI, NDBI, NBR, EVI, SAVI) from a multi-band raster.",
+            category: ToolCategory::Raster,
+            license_tier: LicenseTier::Open,
+            params: vec![
+                ToolParamSpec {
+                    name: "input",
+                    description: "Input multi-band raster file path.",
+                    required: true,
+                },
+                ToolParamSpec {
+                    name: "index",
+                    description: "Index to compute: ndvi, ndwi, ndbi, nbr, evi, or savi.",
+                    required: true,
+                },
+                ToolParamSpec { name: "red", description: "1-based band number for the red band.", required: false },
+                ToolParamSpec { name: "nir", description: "1-based band number for the near-infrared band.", required: false },
+                ToolParamSpec { name: "green", description: "1-based band number for the green band.", required: false },
+                ToolParamSpec { name: "blue", description: "1-based band number for the blue band.", required: false },
+                ToolParamSpec { name: "swir", description: "1-based band number for the shortwave-infrared band.", required: false },
+                ToolParamSpec {
+                    name: "soil_factor",
+                    description: "Soil-adjustment factor L for SAVI (default 0.5).",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "output",
+                    description: "Optional output raster path. If omitted, the result is stored in memory.",
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        if args.get("input").and_then(Value::as_str).is_none() {
+            return Err(ToolError::Validation(
+                "missing required string parameter 'input'".to_string(),
+            ));
+        }
+        match args.get("index").and_then(Value::as_str) {
+            Some(name) => Index::parse(name).map(|_| ()),
+            None => Err(ToolError::Validation(
+                "missing required parameter 'index'".to_string(),
+            )),
+        }
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = args
+            .get("input")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::Validation("missing required parameter 'input'".to_string()))?;
+        let index = Index::parse(
+            args.get("index")
+                .and_then(Value::as_str)
+                .ok_or_else(|| ToolError::Validation("missing required parameter 'index'".to_string()))?,
+        )?;
+        let output = parse_optional_output(args, "output")?;
+        let soil_factor = args.get("soil_factor").and_then(Value::as_f64).unwrap_or(0.5);
+
+        let raster = load_input_raster(input)?;
+        // Resolve the 0-based band indices each formula needs.
+        let band = |key: &str| -> Result<isize, ToolError> {
+            let n = args.get(key).and_then(Value::as_u64).ok_or_else(|| {
+                ToolError::Validation(format!(
+                    "index '{}' requires the '{key}' band number (1-based)",
+                    args.get("index").and_then(Value::as_str).unwrap_or("?")
+                ))
+            })?;
+            let idx = (n.max(1) - 1) as isize;
+            if idx as usize >= raster.bands {
+                return Err(ToolError::Validation(format!(
+                    "band {n} out of range (raster has {} band(s))",
+                    raster.bands
+                )));
+            }
+            Ok(idx)
+        };
+
+        let (red, nir, green, blue, swir) = match index {
+            Index::Ndvi => (Some(band("red")?), Some(band("nir")?), None, None, None),
+            Index::Savi => (Some(band("red")?), Some(band("nir")?), None, None, None),
+            Index::Evi => (Some(band("red")?), Some(band("nir")?), None, Some(band("blue")?), None),
+            Index::Ndwi => (None, Some(band("nir")?), Some(band("green")?), None, None),
+            Index::Ndbi => (None, Some(band("nir")?), None, None, Some(band("swir")?)),
+            Index::Nbr => (None, Some(band("nir")?), None, None, Some(band("swir")?)),
+        };
+
+        let nodata = raster.nodata;
+        let rows = raster.rows as isize;
+        let cols = raster.cols as isize;
+        let valid = |b: Option<isize>, row: isize, col: isize| -> Option<f64> {
+            let b = b?;
+            let v = raster.get(b, row, col);
+            if v == nodata || !v.is_finite() {
+                None
+            } else {
+                Some(v)
+            }
+        };
+
+        ctx.progress.info("computing spectral index");
+        let mut data = vec![INDEX_NODATA; (rows * cols) as usize];
+        for row in 0..rows {
+            for col in 0..cols {
+                let r = valid(red, row, col);
+                let n = valid(nir, row, col);
+                let g = valid(green, row, col);
+                let bl = valid(blue, row, col);
+                let sw = valid(swir, row, col);
+                let value = match index {
+                    Index::Ndvi => norm_diff(n, r),
+                    Index::Ndwi => norm_diff(g, n),
+                    Index::Ndbi => norm_diff(sw, n),
+                    Index::Nbr => norm_diff(n, sw),
+                    Index::Evi => match (n, r, bl) {
+                        (Some(n), Some(r), Some(b)) => {
+                            let denom = n + 6.0 * r - 7.5 * b + 1.0;
+                            if denom == 0.0 { None } else { Some(2.5 * (n - r) / denom) }
+                        }
+                        _ => None,
+                    },
+                    Index::Savi => match (n, r) {
+                        (Some(n), Some(r)) => {
+                            let denom = n + r + soil_factor;
+                            if denom == 0.0 { None } else { Some((1.0 + soil_factor) * (n - r) / denom) }
+                        }
+                        _ => None,
+                    },
+                };
+                if let Some(v) = value.filter(|v| v.is_finite()) {
+                    data[(row * cols + col) as usize] = v;
+                }
+            }
+            ctx.progress.progress((row as f64 + 1.0) / rows as f64);
+        }
+
+        let out = raster_like_with_data(&raster, data, INDEX_NODATA, DataType::F32)?;
+        let out_path = write_or_store_output(out, output)?;
+
+        let mut outputs = std::collections::BTreeMap::new();
+        outputs.insert("output".to_string(), json!(out_path));
+        outputs.insert("rows".to_string(), json!(rows));
+        outputs.insert("cols".to_string(), json!(cols));
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+/// Normalized difference `(a - b) / (a + b)`; `None` if either is missing or the
+/// sum is zero.
+fn norm_diff(a: Option<f64>, b: Option<f64>) -> Option<f64> {
+    match (a, b) {
+        (Some(a), Some(b)) => {
+            let sum = a + b;
+            if sum == 0.0 {
+                None
+            } else {
+                Some((a - b) / sum)
+            }
+        }
+        _ => None,
+    }
+}

--- a/crates/geolibre-tools/src/spectral_index.rs
+++ b/crates/geolibre-tools/src/spectral_index.rs
@@ -85,7 +85,7 @@ impl Tool for SpectralIndexTool {
     }
 
     fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
-        if args.get("input").and_then(Value::as_str).is_none() {
+        if args.get("input").and_then(Value::as_str).map(str::trim).unwrap_or("").is_empty() {
             return Err(ToolError::Validation(
                 "missing required string parameter 'input'".to_string(),
             ));
@@ -120,7 +120,12 @@ impl Tool for SpectralIndexTool {
                     args.get("index").and_then(Value::as_str).unwrap_or("?")
                 ))
             })?;
-            let idx = (n.max(1) - 1) as isize;
+            if n == 0 {
+                return Err(ToolError::Validation(format!(
+                    "'{key}' band number is 1-based and must be >= 1"
+                )));
+            }
+            let idx = (n - 1) as isize;
             if idx as usize >= raster.bands {
                 return Err(ToolError::Validation(format!(
                     "band {n} out of range (raster has {} band(s))",

--- a/crates/geolibre-tools/src/vector_convert.rs
+++ b/crates/geolibre-tools/src/vector_convert.rs
@@ -40,7 +40,7 @@ impl Tool for VectorConvertTool {
     }
 
     fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
-        if args.get("input").and_then(Value::as_str).is_none() {
+        if args.get("input").and_then(Value::as_str).map(str::trim).unwrap_or("").is_empty() {
             return Err(ToolError::Validation(
                 "missing required string parameter 'input'".to_string(),
             ));

--- a/crates/geolibre-tools/src/vector_convert.rs
+++ b/crates/geolibre-tools/src/vector_convert.rs
@@ -1,0 +1,70 @@
+//! GeoLibre tool: convert a vector dataset between formats.
+//!
+//! Reads any format `wbvector` understands (GeoJSON, Shapefile, FlatGeobuf,
+//! GeoPackage, GeoParquet, GML, GPX, KML, ...) and writes it back out in the
+//! format implied by the output path's extension. One tool instead of a matrix
+//! of format-specific converters.
+
+use serde_json::{json, Value};
+use wbcore::{
+    LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata,
+    ToolParamSpec, ToolRunResult,
+};
+
+use crate::vector_common::{load_input_layer, parse_optional_str, write_or_store_layer};
+
+/// Reads a vector dataset and writes it to another vector format.
+pub struct VectorConvertTool;
+
+impl Tool for VectorConvertTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "vector_convert",
+            display_name: "Vector Convert",
+            summary: "Convert a vector dataset to another format (the output extension picks the driver).",
+            category: ToolCategory::Conversion,
+            license_tier: LicenseTier::Open,
+            params: vec![
+                ToolParamSpec {
+                    name: "input",
+                    description: "Input vector file path (format auto-detected) or in-memory handle.",
+                    required: true,
+                },
+                ToolParamSpec {
+                    name: "output",
+                    description: "Output vector path; the driver is taken from its extension (.geojson, .fgb, .shp, .gpkg, .parquet, ...). If omitted, the layer is stored in memory.",
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        if args.get("input").and_then(Value::as_str).is_none() {
+            return Err(ToolError::Validation(
+                "missing required string parameter 'input'".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = args
+            .get("input")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::Validation("missing required parameter 'input'".to_string()))?;
+        let output = parse_optional_str(args, "output")?;
+
+        ctx.progress.info("reading input vector");
+        let layer = load_input_layer(input)?;
+        let feature_count = layer.len();
+
+        ctx.progress.info("writing output vector");
+        let out_path = write_or_store_layer(layer, output)?;
+
+        let mut outputs = std::collections::BTreeMap::new();
+        outputs.insert("output".to_string(), json!(out_path));
+        outputs.insert("feature_count".to_string(), json!(feature_count));
+        Ok(ToolRunResult { outputs })
+    }
+}

--- a/crates/geolibre-tools/src/write_pmtiles.rs
+++ b/crates/geolibre-tools/src/write_pmtiles.rs
@@ -5,7 +5,6 @@
 //! single-file web-map tile format), so a whole basemap layer is one download.
 
 use std::f64::consts::PI;
-use std::path::Path;
 
 use serde_json::{json, Value};
 use wbcore::{
@@ -14,7 +13,7 @@ use wbcore::{
 };
 use wbraster::{Raster, ResampleMethod};
 
-use crate::common::load_input_raster;
+use crate::common::{load_input_raster, write_bytes};
 use crate::pmtiles::{self, LonLatBounds, Tile};
 use crate::raster_to_tiles::{
     native_zoom, render_tile, tile_range, MAX_TILES, ORIGIN, TILE_SIZE, WEB_MERCATOR_EPSG,
@@ -198,16 +197,4 @@ fn require_str<'a>(args: &'a ToolArgs, key: &str) -> Result<&'a str, ToolError> 
         .and_then(Value::as_str)
         .filter(|s| !s.trim().is_empty())
         .ok_or_else(|| ToolError::Validation(format!("missing required string parameter '{key}'")))
-}
-
-fn write_bytes(path: &str, bytes: &[u8]) -> Result<(), ToolError> {
-    if let Some(parent) = Path::new(path).parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent).map_err(|e| {
-                ToolError::Execution(format!("failed creating output directory: {e}"))
-            })?;
-        }
-    }
-    std::fs::write(path, bytes)
-        .map_err(|e| ToolError::Execution(format!("failed writing output file: {e}")))
 }

--- a/crates/geolibre-tools/src/write_pmtiles.rs
+++ b/crates/geolibre-tools/src/write_pmtiles.rs
@@ -1,0 +1,213 @@
+//! GeoLibre tool: render a raster into a single PMTiles archive.
+//!
+//! Like `raster_to_tiles`, but instead of a `{z}/{x}/{y}.png` directory tree it
+//! packs the Web Mercator tile pyramid into one `.pmtiles` file (the modern
+//! single-file web-map tile format), so a whole basemap layer is one download.
+
+use std::f64::consts::PI;
+use std::path::Path;
+
+use serde_json::{json, Value};
+use wbcore::{
+    LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata,
+    ToolParamSpec, ToolRunResult,
+};
+use wbraster::{Raster, ResampleMethod};
+
+use crate::common::load_input_raster;
+use crate::pmtiles::{self, LonLatBounds, Tile};
+use crate::raster_to_tiles::{
+    native_zoom, render_tile, tile_range, MAX_TILES, ORIGIN, TILE_SIZE, WEB_MERCATOR_EPSG,
+};
+use crate::render::Colormap;
+use crate::reproject_raster::parse_resample;
+
+/// Web Mercator (EPSG:3857) sphere radius, for the meters -> lon/lat inverse.
+const R: f64 = 6_378_137.0;
+
+/// Renders a raster into a single PMTiles archive.
+pub struct WritePmTilesTool;
+
+impl Tool for WritePmTilesTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "write_pmtiles",
+            display_name: "Raster to PMTiles",
+            summary: "Render a raster into a single PMTiles archive (Web Mercator PNG tile pyramid).",
+            category: ToolCategory::Conversion,
+            license_tier: LicenseTier::Open,
+            params: vec![
+                ToolParamSpec { name: "input", description: "Input raster file path. Must carry a source CRS (EPSG or WKT).", required: true },
+                ToolParamSpec { name: "output", description: "Output PMTiles file path (e.g. /work/dem.pmtiles).", required: true },
+                ToolParamSpec { name: "min_zoom", description: "Minimum zoom level (default: a single native zoom matching the raster resolution).", required: false },
+                ToolParamSpec { name: "max_zoom", description: "Maximum zoom level (default: same as min_zoom).", required: false },
+                ToolParamSpec { name: "band", description: "1-based band to render (default 1).", required: false },
+                ToolParamSpec { name: "colormap", description: "Colormap: viridis (default), magma, turbo, terrain, or grayscale.", required: false },
+                ToolParamSpec { name: "method", description: "Resampling method: bilinear (default), nearest, cubic.", required: false },
+                ToolParamSpec { name: "min", description: "Value mapped to the low end of the colormap (default: band minimum).", required: false },
+                ToolParamSpec { name: "max", description: "Value mapped to the high end of the colormap (default: band maximum).", required: false },
+            ],
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        for key in ["input", "output"] {
+            if args.get(key).and_then(Value::as_str).is_none() {
+                return Err(ToolError::Validation(format!(
+                    "missing required string parameter '{key}'"
+                )));
+            }
+        }
+        if let Some(c) = args.get("colormap").and_then(Value::as_str) {
+            Colormap::parse(c)?;
+        }
+        if let Some(m) = args.get("method").and_then(Value::as_str) {
+            parse_resample(m)?;
+        }
+        Ok(())
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = require_str(args, "input")?;
+        let output = require_str(args, "output")?;
+        let band_1based = args.get("band").and_then(Value::as_u64).unwrap_or(1).max(1);
+        let band = (band_1based - 1) as isize;
+        let colormap = match args.get("colormap").and_then(Value::as_str) {
+            Some(c) => Colormap::parse(c)?,
+            None => Colormap::Viridis,
+        };
+        let method = match args.get("method").and_then(Value::as_str) {
+            Some(m) => parse_resample(m)?,
+            None => ResampleMethod::Bilinear,
+        };
+
+        let raster = load_input_raster(input)?;
+        if band as usize >= raster.bands {
+            return Err(ToolError::Validation(format!(
+                "band {band_1based} out of range (raster has {} band(s))",
+                raster.bands
+            )));
+        }
+
+        ctx.progress.info("reprojecting to EPSG:3857");
+        let merc: Raster = if raster.crs.epsg == Some(WEB_MERCATOR_EPSG) {
+            raster
+        } else {
+            if raster.crs.epsg.is_none() && raster.crs.wkt.is_none() && raster.crs.proj4.is_none() {
+                return Err(ToolError::Validation(
+                    "input raster has no source CRS (EPSG/WKT/PROJ); cannot tile".to_string(),
+                ));
+            }
+            raster
+                .reproject_to_epsg(WEB_MERCATOR_EPSG, method)
+                .map_err(|e| ToolError::Execution(format!("reprojection to 3857 failed: {e}")))?
+        };
+
+        let stats = merc
+            .statistics_band(band)
+            .map_err(|e| ToolError::Execution(format!("failed computing band statistics: {e}")))?;
+        let min = args.get("min").and_then(Value::as_f64).unwrap_or(stats.min);
+        let max = args.get("max").and_then(Value::as_f64).unwrap_or(stats.max);
+        if !min.is_finite() || !max.is_finite() {
+            return Err(ToolError::Execution(
+                "raster band has no finite values to render".to_string(),
+            ));
+        }
+
+        let native = native_zoom(merc.cell_size_x.abs());
+        let min_zoom = args.get("min_zoom").and_then(Value::as_u64).map(|z| z as u32).unwrap_or(native);
+        let max_zoom = args
+            .get("max_zoom")
+            .and_then(Value::as_u64)
+            .map(|z| z as u32)
+            .unwrap_or(min_zoom)
+            .max(min_zoom);
+        if max_zoom > 24 {
+            return Err(ToolError::Validation("max_zoom must be <= 24".to_string()));
+        }
+
+        let ex = merc.extent();
+        let mut tiles: Vec<Tile> = Vec::new();
+        let mut total = 0usize;
+        for z in min_zoom..=max_zoom {
+            let n = 1u64 << z;
+            let span = (2.0 * ORIGIN) / n as f64;
+            let (tx_min, tx_max) = tile_range(ex.x_min, ex.x_max, -ORIGIN, span, n);
+            let (ty_min, ty_max) = tile_range(ORIGIN - ex.y_max, ORIGIN - ex.y_min, 0.0, span, n);
+            total += ((tx_max - tx_min + 1) as usize) * ((ty_max - ty_min + 1) as usize);
+            if total > MAX_TILES {
+                return Err(ToolError::Validation(format!(
+                    "tile pyramid would exceed {MAX_TILES} tiles; narrow the zoom range (min_zoom/max_zoom)"
+                )));
+            }
+            for tx in tx_min..=tx_max {
+                for ty in ty_min..=ty_max {
+                    let x0 = -ORIGIN + tx as f64 * span;
+                    let y_top = ORIGIN - ty as f64 * span;
+                    if let Some(png) =
+                        render_tile(&merc, band, x0, y_top, span, method, colormap, min, max)?
+                    {
+                        tiles.push(Tile { z: z as u8, x: tx as u32, y: ty as u32, data: png });
+                    }
+                }
+            }
+            ctx.progress.progress((z - min_zoom + 1) as f64 / (max_zoom - min_zoom + 1) as f64);
+        }
+
+        let tile_count = tiles.len();
+        if tile_count == 0 {
+            return Err(ToolError::Execution(
+                "no tiles produced (raster band is entirely no-data?)".to_string(),
+            ));
+        }
+
+        let bounds = LonLatBounds {
+            min_lon: merc_to_lon(ex.x_min),
+            min_lat: merc_to_lat(ex.y_min),
+            max_lon: merc_to_lon(ex.x_max),
+            max_lat: merc_to_lat(ex.y_max),
+        };
+
+        ctx.progress.info("packing PMTiles archive");
+        let archive = pmtiles::build(tiles, &bounds, min_zoom as u8, max_zoom as u8)?;
+        write_bytes(output, &archive)?;
+
+        let mut outputs = std::collections::BTreeMap::new();
+        outputs.insert("output".to_string(), json!(output));
+        outputs.insert("min_zoom".to_string(), json!(min_zoom));
+        outputs.insert("max_zoom".to_string(), json!(max_zoom));
+        outputs.insert("tiles".to_string(), json!(tile_count));
+        outputs.insert("bytes".to_string(), json!(archive.len()));
+        let _ = TILE_SIZE; // referenced for clarity that tiles are 256px
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+/// Web Mercator meters -> longitude (degrees).
+fn merc_to_lon(x: f64) -> f64 {
+    (x / ORIGIN) * 180.0
+}
+
+/// Web Mercator meters -> latitude (degrees).
+fn merc_to_lat(y: f64) -> f64 {
+    (2.0 * (y / R).exp().atan() - PI / 2.0).to_degrees()
+}
+
+fn require_str<'a>(args: &'a ToolArgs, key: &str) -> Result<&'a str, ToolError> {
+    args.get(key)
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| ToolError::Validation(format!("missing required string parameter '{key}'")))
+}
+
+fn write_bytes(path: &str, bytes: &[u8]) -> Result<(), ToolError> {
+    if let Some(parent) = Path::new(path).parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                ToolError::Execution(format!("failed creating output directory: {e}"))
+            })?;
+        }
+    }
+    std::fs::write(path, bytes)
+        .map_err(|e| ToolError::Execution(format!("failed writing output file: {e}")))
+}


### PR DESCRIPTION
## Summary
Four new pure-Rust, WASM-ready tools in `geolibre-tools`:

| Tool | What it does |
|---|---|
| `spectral_index` | NDVI / NDWI / NDBI / NBR / EVI / SAVI from a multi-band raster (caller maps band numbers to red/nir/green/blue/swir). |
| `vector_convert` | Read any `wbvector` format, write the format implied by the output extension. One tool instead of a converter matrix. |
| `render_vector_png` | Rasterize points/lines/polygons (holes honored) to an RGBA PNG map image - the vector analog of `render_raster_png`. |
| `write_pmtiles` | Pack the Web Mercator PNG tile pyramid into a single PMTiles v3 archive. |

The PMTiles writer is hand-rolled (gzip via `flate2`, no async/backend deps); its tile ids and directory encoding match the spec. `raster_to_tiles`' tile helpers are now `pub(crate)` so `write_pmtiles` reuses the tile rendering.

## Test plan
- [x] `cargo test -p geolibre-tools` (25 passed, incl. PMTiles tile-id/varint/header)
- [x] `spectral_index` NDVI numerically verified against known values; missing-band validation
- [x] `render_vector_png` renders 540 real building footprints correctly (filled polygons + outlines)
- [x] `write_pmtiles` output **validated by the reference `pmtiles` Python reader** (v3, PNG, 52 tiles, `get(z,x,y)` returns a valid PNG)
- [x] All four verified through the `wasm32-wasip1` WASI runtime (747 tools total)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PMTiles archive tool to package raster tiles into a Web Mercator `.pmtiles` pyramid with configurable zoom levels and rendering range
  * Added spectral index tool supporting NDVI, NDWI, NDBI, NBR, EVI, and SAVI
  * Added vector-to-PNG rasterizer with configurable width/height and styling (fill, stroke, background)  
  * Added vector format converter to transform datasets between supported formats
* **Documentation**
  * Updated the README tools table to include the newly added tools
<!-- end of auto-generated comment: release notes by coderabbit.ai -->