### PR TITLE
feat(manifests): emit per-param I/O schemas (self-describing tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,19 @@ in the Python original.
    reading and writing rasters by path).
 2. Push it into the list returned by `geolibre_tools()` in
    `crates/geolibre-tools/src/lib.rs`.
-3. Rebuild (`./build.sh`); it appears in `listTools()` automatically.
+3. **Declare each parameter's schema** in `geolibre_param_schemas()` (same file):
+   add a match arm mapping the tool id to its params, e.g.
+   `input` -> `ToolParamSchema::input_raster()`, `output` ->
+   `ToolParamSchema::output_raster()` (or `output(ToolDatasetSchema::File)` for a
+   non-dataset file), a count -> `scalar_integer()`, a factor -> `scalar_float()`,
+   a flag -> `bool()`, a fixed choice -> `enum_values(&[...])`. This is what makes
+   `geolibre manifests` emit an accurate `io_role`/`data_kind`/`schema` per param,
+   so host UIs route raster/vector inputs and render the right widget. Without it,
+   the manifest falls back to keyword inference, which mis-types scalars whose
+   description mentions a dataset (a flag that "sorts features" would read as a
+   vector input). A unit test (`every_tool_has_explicit_param_schemas`) fails if a
+   tool's param is left without a schema.
+4. Rebuild (`./build.sh`); it appears in `listTools()` automatically.
 
 The crate depends only on `wbcore` plus the data crates a tool needs (e.g.
 `wbraster`), so the same tools can later back a native CLI or the Python sidecar,

--- a/crates/geolibre-cli/src/main.rs
+++ b/crates/geolibre-cli/src/main.rs
@@ -69,6 +69,16 @@ fn tag_source(manifest: &mut Value, geolibre_ids: &HashSet<String>) {
     }
 }
 
+/// Serializes a manifest with per-param I/O schema. GeoLibre-authored tools use
+/// their explicit schemas ([`geolibre_tools::geolibre_param_schemas`]); every
+/// other tool falls back to wbcore's name/description-based inference.
+fn enriched_manifest(manifest: &wbcore::ToolManifest) -> Value {
+    match geolibre_tools::geolibre_param_schemas(&manifest.id) {
+        Some(schemas) => wbcore::manifest_with_param_schema_json(manifest, &schemas),
+        None => wbcore::manifest_with_io_schema_json(manifest),
+    }
+}
+
 fn main() -> ExitCode {
     let argv: Vec<String> = std::env::args().skip(1).collect();
     let Some(command) = argv.first() else {
@@ -87,21 +97,21 @@ fn main() -> ExitCode {
         "manifests" => {
             let registry = build_registry();
             let geolibre_ids = geolibre_tool_ids();
-            match serde_json::to_value(registry.manifests()) {
-                Ok(mut value) => {
-                    if let Some(arr) = value.as_array_mut() {
-                        for m in arr.iter_mut() {
-                            tag_source(m, &geolibre_ids);
-                        }
-                    }
-                    println!("{value}");
-                    ExitCode::SUCCESS
-                }
-                Err(e) => {
-                    eprintln!("failed to serialize manifests: {e}");
-                    ExitCode::from(1)
-                }
-            }
+            // Emit the I/O-enriched manifest (each param's `schema`, `io_role`,
+            // and `data_kind`) rather than the bare manifest, so host UIs can
+            // route raster/vector/lidar inputs and render widgets without a
+            // separate catalog. Mirrors what the ArcGIS catalog snapshot carries.
+            let arr: Vec<Value> = registry
+                .manifests()
+                .iter()
+                .map(|m| {
+                    let mut value = enriched_manifest(m);
+                    tag_source(&mut value, &geolibre_ids);
+                    value
+                })
+                .collect();
+            println!("{}", Value::Array(arr));
+            ExitCode::SUCCESS
         }
         "manifest" => {
             let Some(id) = argv.get(1) else {
@@ -110,17 +120,12 @@ fn main() -> ExitCode {
             };
             let registry = build_registry();
             match registry.manifests().into_iter().find(|m| &m.id == id) {
-                Some(manifest) => match serde_json::to_value(&manifest) {
-                    Ok(mut value) => {
-                        tag_source(&mut value, &geolibre_tool_ids());
-                        println!("{value}");
-                        ExitCode::SUCCESS
-                    }
-                    Err(e) => {
-                        eprintln!("failed to serialize manifest: {e}");
-                        ExitCode::from(1)
-                    }
-                },
+                Some(manifest) => {
+                    let mut value = enriched_manifest(&manifest);
+                    tag_source(&mut value, &geolibre_tool_ids());
+                    println!("{value}");
+                    ExitCode::SUCCESS
+                }
                 None => {
                     eprintln!("tool not found: {id}");
                     ExitCode::from(1)

--- a/crates/geolibre-tools/src/lib.rs
+++ b/crates/geolibre-tools/src/lib.rs
@@ -29,7 +29,9 @@ mod vector_common;
 mod vector_convert;
 mod write_pmtiles;
 
-use wbcore::Tool;
+use std::collections::BTreeMap;
+
+use wbcore::{Tool, ToolDatasetSchema, ToolParamSchema};
 
 /// Returns every GeoLibre-authored tool as a boxed [`Tool`].
 ///
@@ -62,6 +64,154 @@ pub fn geolibre_tools() -> Vec<Box<dyn Tool>> {
     ]
 }
 
+fn schemas(entries: &[(&str, ToolParamSchema)]) -> BTreeMap<String, ToolParamSchema> {
+    entries
+        .iter()
+        .map(|(name, schema)| ((*name).to_string(), schema.clone()))
+        .collect()
+}
+
+/// Explicit parameter schemas for the GeoLibre-authored tools, keyed by tool id.
+///
+/// The manifest emitter (`geolibre-cli`) feeds these to
+/// `wbcore::manifest_with_param_schema_json` so each param carries an accurate
+/// `io_role`/`data_kind`/`schema`. Without them, the keyword-based inference
+/// mis-types scalars whose descriptions mention a dataset — e.g.
+/// `write_geoparquet.hilbert_sort` ("sort features…") would read as a vector
+/// input, and `delineate_*.min_depth/min_height` ("matching lidar") as LiDAR —
+/// which would make a host UI demand a layer for a plain number/flag.
+pub fn geolibre_param_schemas(tool_id: &str) -> Option<BTreeMap<String, ToolParamSchema>> {
+    let raster_in = ToolParamSchema::input_raster;
+    let raster_out = ToolParamSchema::output_raster;
+    let vector_in = ToolParamSchema::input_vector_any;
+    let vector_out = ToolParamSchema::output_vector_any;
+    let file_out = || ToolParamSchema::output(ToolDatasetSchema::File);
+    let table_out = || ToolParamSchema::output(ToolDatasetSchema::Table);
+    let int = ToolParamSchema::scalar_integer;
+    let float = ToolParamSchema::scalar_float;
+    let colormaps = || {
+        ToolParamSchema::enum_values(&["viridis", "magma", "turbo", "terrain", "grayscale"])
+    };
+
+    let map = match tool_id {
+        "raster_normalize" => schemas(&[
+            ("input", raster_in()),
+            ("output", raster_out()),
+            ("band", int()),
+        ]),
+        "dem_filter" => schemas(&[
+            ("input", raster_in()),
+            ("output", raster_out()),
+            ("filter", ToolParamSchema::enum_values(&["mean", "median", "gaussian"])),
+            ("kernel_size", int()),
+            ("sigma", float()),
+            ("band", int()),
+        ]),
+        "extract_sinks" => schemas(&[
+            ("input", raster_in()),
+            ("output", raster_out()),
+            ("min_size", int()),
+            ("region_output", raster_out()),
+            ("depth_output", raster_out()),
+            ("filled_output", raster_out()),
+            ("csv_output", table_out()),
+            ("vector_output", vector_out()),
+            ("flat_increment", float()),
+        ]),
+        "delineate_depressions" => schemas(&[
+            ("input", raster_in()),
+            ("output", raster_out()),
+            ("level_output", raster_out()),
+            ("csv_output", table_out()),
+            ("vector_output", vector_out()),
+            ("min_size", int()),
+            ("min_depth", float()),
+            ("interval", float()),
+        ]),
+        "delineate_mounts" => schemas(&[
+            ("input", raster_in()),
+            ("output", raster_out()),
+            ("level_output", raster_out()),
+            ("csv_output", table_out()),
+            ("vector_output", vector_out()),
+            ("min_size", int()),
+            ("min_height", float()),
+            ("interval", float()),
+            ("delta", float()),
+        ]),
+        "reproject_raster" => schemas(&[
+            ("input", raster_in()),
+            ("epsg", int()),
+            ("method", ToolParamSchema::enum_values(&["nearest", "bilinear", "cubic", "lanczos"])),
+            ("output", raster_out()),
+        ]),
+        "render_raster_png" => schemas(&[
+            ("input", raster_in()),
+            ("output", file_out()),
+            ("band", int()),
+            ("colormap", colormaps()),
+            ("min", float()),
+            ("max", float()),
+        ]),
+        "raster_to_tiles" => schemas(&[
+            ("input", raster_in()),
+            ("output_dir", file_out()),
+            ("min_zoom", int()),
+            ("max_zoom", int()),
+            ("band", int()),
+            ("colormap", colormaps()),
+            ("method", ToolParamSchema::enum_values(&["bilinear", "nearest", "cubic"])),
+            ("min", float()),
+            ("max", float()),
+        ]),
+        "write_pmtiles" => schemas(&[
+            ("input", raster_in()),
+            ("output", file_out()),
+            ("min_zoom", int()),
+            ("max_zoom", int()),
+            ("band", int()),
+            ("colormap", colormaps()),
+            ("method", ToolParamSchema::enum_values(&["bilinear", "nearest", "cubic"])),
+            ("min", float()),
+            ("max", float()),
+        ]),
+        "spectral_index" => schemas(&[
+            ("input", raster_in()),
+            ("index", ToolParamSchema::enum_values(&["ndvi", "ndwi", "ndbi", "nbr", "evi", "savi"])),
+            ("red", int()),
+            ("nir", int()),
+            ("green", int()),
+            ("blue", int()),
+            ("swir", int()),
+            ("soil_factor", float()),
+            ("output", raster_out()),
+        ]),
+        "write_geoparquet" => schemas(&[
+            ("input", vector_in()),
+            ("output", file_out()),
+            ("compression", ToolParamSchema::enum_values(&["zstd", "snappy", "gzip", "uncompressed"])),
+            ("hilbert_sort", ToolParamSchema::bool()),
+        ]),
+        "read_geoparquet" => schemas(&[
+            ("input", ToolParamSchema::input(ToolDatasetSchema::File)),
+            ("output", vector_out()),
+        ]),
+        "vector_convert" => schemas(&[("input", vector_in()), ("output", vector_out())]),
+        "render_vector_png" => schemas(&[
+            ("input", vector_in()),
+            ("output", file_out()),
+            ("width", int()),
+            ("height", int()),
+            ("fill", ToolParamSchema::string()),
+            ("stroke", ToolParamSchema::string()),
+            ("stroke_width", float()),
+            ("background", ToolParamSchema::string()),
+        ]),
+        _ => return None,
+    };
+    Some(map)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -73,6 +223,26 @@ mod tests {
         // Every tool must have a non-empty id.
         for tool in &tools {
             assert!(!tool.metadata().id.is_empty());
+        }
+    }
+
+    #[test]
+    fn every_tool_has_explicit_param_schemas() {
+        // A GeoLibre tool without explicit schemas falls back to keyword-based
+        // inference, which mis-types scalars (e.g. "...features..." -> vector).
+        // Guard that every tool declares a schema for each of its params.
+        for tool in geolibre_tools() {
+            let meta = tool.metadata();
+            let schemas = geolibre_param_schemas(&meta.id)
+                .unwrap_or_else(|| panic!("missing param schemas for tool '{}'", meta.id));
+            for param in &meta.params {
+                assert!(
+                    schemas.contains_key(param.name),
+                    "tool '{}' is missing a schema for param '{}'",
+                    meta.id,
+                    param.name
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

`geolibre manifests` serialized the bare `ToolManifest`, whose params carry only `name`/`description`/`required`. A host UI (e.g. GeoLibre's Processing → Whitebox toolbox) needs each param's **kind** to route raster/vector/lidar inputs and render the right widget — and was relying on a separate catalog. As a result, the GeoLibre-authored tools (`write_geoparquet`, `delineate_depressions`, `reproject_raster`, `spectral_index`, …) couldn't be wired into the toolbox at all.

This makes the manifests **self-describing**:

- **`geolibre-cli`** now emits the I/O-enriched manifest (each param gets `io_role`, `data_kind`, and a `schema`). GeoLibre-authored tools use explicit schemas; every other tool falls back to wbcore's name/description inference (`manifest_with_io_schema_json`).
- **`geolibre-tools`** adds `geolibre_param_schemas(tool_id)` declaring an explicit `ToolParamSchema` for every param of all 14 GeoLibre tools.

### Why explicit schemas (not just inference)

wbcore's keyword inference mis-types scalars whose **description mentions a dataset**:

| param | inferred (wrong) | correct |
|---|---|---|
| `write_geoparquet.hilbert_sort` ("sort **features**…") | vector input | bool |
| `delineate_*.min_depth` / `min_height` ("matching **lidar**") | lidar input | float |
| `raster_to_tiles.min_zoom` / `write_pmtiles.min_zoom` | raster input | integer |

Left to inference, a host would demand a *layer* for a plain flag/number. The explicit schemas also type the rest accurately (enums for `colormap`/`method`/`compression`/`index`, integers for bands/zooms, floats for factors, file outputs for `.parquet`/`.png`/`.pmtiles`).

## Tests

- New `every_tool_has_explicit_param_schemas` asserts no GeoLibre tool param is left to inference.
- Existing suite passes (`cargo test -p geolibre-tools`: 26 tests). Verified the emitted manifest for every GeoLibre tool has correct `io_role`/`data_kind`/`schema`.

## Docs

README "Adding a new tool" now includes declaring param schemas as a step.

This unblocks GeoLibre surfacing the GeoLibre-authored tools in its toolbox (a follow-up consumes the enriched manifests).