### PR TITLE
feat(docker): self-hostable demo image, compose template, and GHCR publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Keep the build context small and reproducible. Everything the multi-stage
+# build needs (crates/, vendor/, npm/, examples/, demo/, build.sh, Cargo.*) is
+# tracked source; the heavy/generated bits below are rebuilt inside the image.
+target
+.git
+.github
+site
+node_modules
+**/node_modules
+*.log

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,54 @@
+name: Publish demo image
+
+# Build and push the self-hostable demo image to GHCR. The WASM build is heavy
+# (a few minutes), so this runs on releases/tags rather than every push to main;
+# trigger it by hand from the Actions tab when needed.
+on:
+  release:
+    types: [published]
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags and labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=tag
+            type=sha
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_REF=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# syntax=docker/dockerfile:1
+#
+# Self-hostable image for the geolibre-rust browser demo.
+#
+# Stage 1 compiles the two WASM artifacts (wasm-bindgen library + WASI tool
+# runner) with the same toolchain CI uses and assembles the static site exactly
+# like .github/workflows/pages.yml. Stage 2 serves that site with nginx — no
+# Rust, no GDAL, no server-side compute; every tool still runs in the visitor's
+# browser.
+#
+#   docker build -t geolibre-rust .
+#   docker run --rm -p 8080:80 geolibre-rust   # http://localhost:8080
+
+# ---- Stage 1: build the WASM artifacts and assemble the site ----------------
+FROM rust:1-bookworm AS builder
+
+# wasm targets + tooling. binaryen provides wasm-opt (shrinks the WASI runner);
+# clang/llvm/lld let cc-rs cross-compile C deps to wasm32-unknown-unknown (the
+# browser-library target — GitHub's CI runners ship these preinstalled); wasi-sdk
+# is the separate C toolchain for the wasm32-wasip1 WASI runner (zstd-sys).
+RUN rustup target add wasm32-unknown-unknown wasm32-wasip1 \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends binaryen curl ca-certificates clang llvm lld \
+ && rm -rf /var/lib/apt/lists/* \
+ && curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+ENV WASI_SDK_VERSION=33.0
+RUN curl -sL "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-${WASI_SDK_VERSION}-x86_64-linux.tar.gz" \
+      | tar xz -C /opt
+ENV WASI_SDK=/opt/wasi-sdk-${WASI_SDK_VERSION}-x86_64-linux \
+    CC_wasm32_wasip1=/opt/wasi-sdk-${WASI_SDK_VERSION}-x86_64-linux/bin/clang \
+    AR_wasm32_wasip1=/opt/wasi-sdk-${WASI_SDK_VERSION}-x86_64-linux/bin/llvm-ar \
+    CFLAGS_wasm32_wasip1=--sysroot=/opt/wasi-sdk-${WASI_SDK_VERSION}-x86_64-linux/share/wasi-sysroot
+
+WORKDIR /src
+COPY . .
+
+# Cache-bust token baked into index.html (mirrors pages.yml's __BUILD__ swap so
+# returning visitors never mix an old cached loader with a fresh module). The
+# publish workflow passes the commit SHA; local builds default to "docker".
+ARG BUILD_REF=docker
+RUN ./build.sh \
+ && mkdir -p site \
+ && cp demo/index.html           site/index.html \
+ && cp npm/tools.mjs             site/tools.mjs \
+ && cp npm/geolibre-cli.wasm     site/geolibre-cli.wasm \
+ && cp npm/geolibre_wasm.js      site/geolibre_wasm.js \
+ && cp npm/geolibre_wasm_bg.wasm site/geolibre_wasm_bg.wasm \
+ && cp examples/sample.tif       site/sample.tif \
+ && sed -i "s/__BUILD__/${BUILD_REF}/g" site/index.html
+
+# ---- Stage 2: serve the static site -----------------------------------------
+FROM nginx:alpine AS runtime
+
+# Ensure .wasm/.mjs are served with the MIME types ES-module + WebAssembly
+# streaming compilation require.
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /src/site /usr/share/nginx/html
+
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -46,6 +46,30 @@ click **Run** to see the exit code, stdout, output files, and a download link.
 sample raster (`examples/sample.tif`) next to the page in a temp directory, so the
 repo's `demo/` stays clean; Ctrl-C stops the server and cleans up.
 
+### Self-host with Docker
+
+The same demo ships as a container image so you can host it yourself. The image
+is a static site (nginx) — every tool still runs in the visitor's browser, so
+there's no server-side compute, GDAL, or database.
+
+Pull the published image with Docker Compose:
+
+```bash
+docker compose up -d        # serves on http://localhost:8080
+```
+
+Or build and run it straight from source (needs only Docker — the Rust/WASM
+toolchain lives inside the build):
+
+```bash
+docker build -t geolibre-rust .
+docker run --rm -p 8080:80 geolibre-rust
+```
+
+Images are published to `ghcr.io/opengeos/geolibre-rust` on each release (and on
+`v*` tags); `:latest` tracks the most recent release. To build from source via
+Compose instead of pulling, uncomment `build: .` in `docker-compose.yml`.
+
 ## Architecture
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+# Self-host the geolibre-rust demo.
+#
+#   docker compose up -d         # pull the published image and serve on :8080
+#
+# Prefer to build from source instead of pulling? Comment out `image:` and
+# uncomment `build: .` below, then run `docker compose up -d --build`.
+services:
+  demo:
+    image: ghcr.io/opengeos/geolibre-rust:latest
+    # build: .
+    ports:
+      - "8080:80"
+    restart: unless-stopped

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,29 @@
+# Static-file server for the geolibre-rust demo.
+#
+# nginx's bundled mime.types (included at the http level) already serves .wasm as
+# application/wasm — which WebAssembly.compileStreaming() requires — but it has
+# no mapping for .mjs. The page is an ES module that does `import ./tools.mjs`,
+# so .mjs must be a JavaScript type or the browser rejects it as octet-stream;
+# the location below supplies that without disturbing the other types.
+server {
+    listen      80;
+    listen      [::]:80;
+    server_name _;
+
+    root  /usr/share/nginx/html;
+    index index.html;
+
+    location ~ \.mjs$ {
+        default_type text/javascript;
+    }
+
+    # Hashed assets (?v=<BUILD_REF>) are safe to cache hard; index.html points at
+    # them, so keep it revalidated to pick up new builds.
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #20 — a self-hosting path for the browser demo, mirroring how
[GeoLibre publishes images](https://github.com/opengeos/GeoLibre/pkgs/container/geolibre)
to GHCR. (Split from #17; the UI parts shipped in #19.)

The image is a **static site** (nginx) — every tool still runs in the visitor's
browser, so there's no server-side compute, GDAL, or database.

### What's here
- **`Dockerfile`** — multi-stage. Stage 1 builds the two WASM artifacts with the
  same toolchain CI uses (wasm32 targets, `wasm-pack`, `binaryen`, `wasi-sdk`),
  runs `build.sh`, and assembles the site exactly like `pages.yml`. Stage 2
  serves it with `nginx:alpine`. A `BUILD_REF` arg fills the `__BUILD__`
  cache-bust token (the workflow passes the commit SHA).
- **`docker/nginx.conf`** — maps `.mjs` to a JavaScript type so the page's
  `import ./tools.mjs` and `WebAssembly.compileStreaming()` both work (the base
  image already serves `.wasm` as `application/wasm`).
- **`docker-compose.yml`** — `docker compose up -d` pulls
  `ghcr.io/opengeos/geolibre-rust` and serves on `:8080`; a commented `build: .`
  switches to building from source.
- **`.github/workflows/docker.yml`** — builds and pushes to GHCR on releases /
  `v*` tags / manual dispatch (the WASM build is heavy, so not on every push to
  `main`). Tags: semver, `sha-*`, and `latest`.
- **README** — a "Self-host with Docker" section.

### Open questions from #20, resolved here
- **Image name/tags:** `ghcr.io/opengeos/geolibre-rust`; `:latest` + semver +
  `sha-*`.
- **Publish trigger:** releases and `v*` tags (plus manual `workflow_dispatch`),
  not every `main` push — happy to switch to `main` builds if you'd prefer.

## Testing

Built and ran locally end to end:
- `docker build` succeeds; final image ~84 MB.
- `nginx -t` passes with no warnings.
- All assets serve `200` with correct `Content-Type` — `.mjs` →
  `text/javascript`, `.wasm` → `application/wasm`, `.tif` → `image/tiff`.
- Cache-bust token is applied (`tools.mjs?v=<BUILD_REF>`).
- A real browser (Chromium/Playwright) against the running container loads **747
  tools** via the WASI runner and renders the merged #19 UI, with no console
  errors.

> Note: the `docker.yml` workflow needs no extra secrets (uses the built-in
> `GITHUB_TOKEN` with `packages: write`), but the first publish requires the repo
> to allow GitHub Actions to create packages, and you may want to link the
> resulting package to the repo for visibility.
