### PR TITLE
fix(demo): correct spatial_join input controls and add conditional fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,7 +2972,7 @@ dependencies = [
 [[package]]
 name = "wbcore"
 version = "0.1.1"
-source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
+source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
 dependencies = [
  "serde",
  "serde_json",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "wbgeotiff"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
+source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -3001,7 +3001,7 @@ dependencies = [
 [[package]]
 name = "wbhdf"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
+source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3012,7 +3012,7 @@ dependencies = [
 [[package]]
 name = "wblidar"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
+source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
 dependencies = [
  "rayon",
  "wbhdf",
@@ -3023,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "wbprojection"
 version = "0.3.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
+source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
 dependencies = [
  "thiserror 1.0.69",
  "wide 1.5.0",
@@ -3032,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "wbraster"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
+source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -3055,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "wbspatialstats"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
+source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
 dependencies = [
  "log",
  "nalgebra",
@@ -3070,7 +3070,7 @@ dependencies = [
 [[package]]
 name = "wbtools_oss"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
+source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
 dependencies = [
  "bincode",
  "chrono",
@@ -3100,7 +3100,7 @@ dependencies = [
 [[package]]
 name = "wbtopology"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
+source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
 dependencies = [
  "rayon",
  "robust",
@@ -3110,7 +3110,7 @@ dependencies = [
 [[package]]
 name = "wbvector"
 version = "0.1.4"
-source = "git+https://github.com/opengeos/whitebox-wasm#1ed146da9f664e7417e77a269a3b1eac41167092"
+source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
 dependencies = [
  "bytes",
  "flatbuffers 24.12.23",

--- a/crates/geolibre-cli/src/main.rs
+++ b/crates/geolibre-cli/src/main.rs
@@ -70,10 +70,14 @@ fn tag_source(manifest: &mut Value, geolibre_ids: &HashSet<String>) {
 }
 
 /// Serializes a manifest with per-param I/O schema. GeoLibre-authored tools use
-/// their explicit schemas ([`geolibre_tools::geolibre_param_schemas`]); every
+/// their explicit schemas ([`geolibre_tools::geolibre_param_schemas`]); a few
+/// upstream whitebox tools whose inference is demonstrably wrong get curated
+/// corrections ([`geolibre_tools::whitebox_param_schema_overrides`]); every
 /// other tool falls back to wbcore's name/description-based inference.
 fn enriched_manifest(manifest: &wbcore::ToolManifest) -> Value {
-    match geolibre_tools::geolibre_param_schemas(&manifest.id) {
+    let explicit = geolibre_tools::geolibre_param_schemas(&manifest.id)
+        .or_else(|| geolibre_tools::whitebox_param_schema_overrides(&manifest.id));
+    match explicit {
         Some(schemas) => wbcore::manifest_with_param_schema_json(manifest, &schemas),
         None => wbcore::manifest_with_io_schema_json(manifest),
     }
@@ -272,5 +276,65 @@ mod tests {
     fn registry_lists_tools() {
         let registry = build_registry();
         assert!(!registry.list().is_empty());
+    }
+
+    // Looks up an enriched-manifest param by name; panics if it's absent.
+    fn param<'a>(manifest: &'a Value, name: &str) -> &'a Value {
+        manifest["params"]
+            .as_array()
+            .expect("params array")
+            .iter()
+            .find(|p| p["name"] == name)
+            .unwrap_or_else(|| panic!("param '{name}' not found"))
+    }
+
+    #[test]
+    fn spatial_join_override_matches_real_params() {
+        // The curated override keys must line up with the tool's actual params,
+        // or a renamed/removed param silently reverts to the bad inference.
+        let registry = build_registry();
+        let manifest = registry
+            .manifests()
+            .into_iter()
+            .find(|m| m.id == "spatial_join")
+            .expect("upstream whitebox_next_gen no longer ships 'spatial_join'");
+        let real: std::collections::BTreeSet<_> =
+            manifest.params.iter().map(|p| p.name.clone()).collect();
+        let keys: std::collections::BTreeSet<_> =
+            geolibre_tools::whitebox_param_schema_overrides("spatial_join")
+                .expect("missing spatial_join override")
+                .into_keys()
+                .collect();
+        assert_eq!(keys, real, "override keys must match spatial_join's params");
+    }
+
+    #[test]
+    fn spatial_join_manifest_renders_correct_controls() {
+        // Regression for the broken demo inputs: layer paths are file inputs, the
+        // strategy/predicate are enums (not a free-form box or a file picker),
+        // and the distance threshold is numeric.
+        let registry = build_registry();
+        let manifest = registry
+            .manifests()
+            .into_iter()
+            .find(|m| m.id == "spatial_join")
+            .expect("spatial_join present");
+        let json = enriched_manifest(&manifest);
+
+        for layer in ["target", "join"] {
+            assert_eq!(param(&json, layer)["schema"]["kind"], "input");
+            assert_eq!(param(&json, layer)["io_role"], "input");
+        }
+        assert_eq!(param(&json, "output")["schema"]["kind"], "output");
+        assert_eq!(param(&json, "distance")["schema"]["kind"], "scalar");
+
+        for enum_param in ["predicate", "strategy"] {
+            let schema = &param(&json, enum_param)["schema"];
+            assert_eq!(schema["kind"], "enum", "{enum_param} should be an enum");
+            assert!(
+                schema["options"].as_array().is_some_and(|o| !o.is_empty()),
+                "{enum_param} should carry its option list"
+            );
+        }
     }
 }

--- a/crates/geolibre-cli/src/main.rs
+++ b/crates/geolibre-cli/src/main.rs
@@ -70,14 +70,10 @@ fn tag_source(manifest: &mut Value, geolibre_ids: &HashSet<String>) {
 }
 
 /// Serializes a manifest with per-param I/O schema. GeoLibre-authored tools use
-/// their explicit schemas ([`geolibre_tools::geolibre_param_schemas`]); a few
-/// upstream whitebox tools whose inference is demonstrably wrong get curated
-/// corrections ([`geolibre_tools::whitebox_param_schema_overrides`]); every
+/// their explicit schemas ([`geolibre_tools::geolibre_param_schemas`]); every
 /// other tool falls back to wbcore's name/description-based inference.
 fn enriched_manifest(manifest: &wbcore::ToolManifest) -> Value {
-    let explicit = geolibre_tools::geolibre_param_schemas(&manifest.id)
-        .or_else(|| geolibre_tools::whitebox_param_schema_overrides(&manifest.id));
-    match explicit {
+    match geolibre_tools::geolibre_param_schemas(&manifest.id) {
         Some(schemas) => wbcore::manifest_with_param_schema_json(manifest, &schemas),
         None => wbcore::manifest_with_io_schema_json(manifest),
     }
@@ -289,30 +285,11 @@ mod tests {
     }
 
     #[test]
-    fn spatial_join_override_matches_real_params() {
-        // The curated override keys must line up with the tool's actual params,
-        // or a renamed/removed param silently reverts to the bad inference.
-        let registry = build_registry();
-        let manifest = registry
-            .manifests()
-            .into_iter()
-            .find(|m| m.id == "spatial_join")
-            .expect("upstream whitebox_next_gen no longer ships 'spatial_join'");
-        let real: std::collections::BTreeSet<_> =
-            manifest.params.iter().map(|p| p.name.clone()).collect();
-        let keys: std::collections::BTreeSet<_> =
-            geolibre_tools::whitebox_param_schema_overrides("spatial_join")
-                .expect("missing spatial_join override")
-                .into_keys()
-                .collect();
-        assert_eq!(keys, real, "override keys must match spatial_join's params");
-    }
-
-    #[test]
     fn spatial_join_manifest_renders_correct_controls() {
-        // Regression for the broken demo inputs: layer paths are file inputs, the
-        // strategy/predicate are enums (not a free-form box or a file picker),
-        // and the distance threshold is numeric.
+        // Regression for the broken demo inputs (opengeos/geolibre-rust#17). These
+        // controls now come from wbcore's improved manifest inference rather than a
+        // curated override: layer paths are file inputs, strategy/predicate are
+        // enums (not a free-form box or a file picker), and distance is numeric.
         let registry = build_registry();
         let manifest = registry
             .manifests()

--- a/crates/geolibre-tools/src/lib.rs
+++ b/crates/geolibre-tools/src/lib.rs
@@ -212,6 +212,59 @@ pub fn geolibre_param_schemas(tool_id: &str) -> Option<BTreeMap<String, ToolPara
     Some(map)
 }
 
+/// Curated parameter-schema corrections for a handful of upstream
+/// `whitebox_next_gen` tools that wbcore's name/description-based inference
+/// mis-types.
+///
+/// These tools are *not* GeoLibre-authored, so they don't appear in
+/// [`geolibre_param_schemas`]; but their inferred schemas are wrong enough to
+/// break a host UI. `spatial_join`, for instance, infers its `target`/`join`
+/// layer paths as plain strings (so a UI renders a text box instead of a file
+/// picker), its numeric `distance` as a string, and its `strategy` enum as a
+/// LiDAR input file. Supplying explicit schemas here lets the manifest emitter
+/// hand consumers an accurate `io_role`/`data_kind`/`schema` for each param.
+///
+/// Keep this list small and evidence-driven: only override a tool whose
+/// inferred schema is demonstrably wrong, and mirror the param order and option
+/// lists the tool documents in its own descriptions.
+pub fn whitebox_param_schema_overrides(
+    tool_id: &str,
+) -> Option<BTreeMap<String, ToolParamSchema>> {
+    let vector_in = ToolParamSchema::input_vector_any;
+    let vector_out = ToolParamSchema::output_vector_any;
+    let float = ToolParamSchema::scalar_float;
+
+    let map = match tool_id {
+        "spatial_join" => schemas(&[
+            ("target", vector_in()),
+            ("join", vector_in()),
+            (
+                "predicate",
+                ToolParamSchema::enum_values(&[
+                    "intersects",
+                    "within",
+                    "contains",
+                    "touches",
+                    "crosses",
+                    "overlaps",
+                    "within_distance",
+                ]),
+            ),
+            ("distance", float()),
+            (
+                "strategy",
+                ToolParamSchema::enum_values(&[
+                    "first", "last", "count", "sum", "mean", "min", "max",
+                ]),
+            ),
+            ("prefix", ToolParamSchema::string()),
+            ("output", vector_out()),
+        ]),
+        _ => return None,
+    };
+    Some(map)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -244,5 +297,22 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn spatial_join_override_has_typed_inputs() {
+        // Guard the curated correction: the layer paths must be file inputs, the
+        // enums must carry their options, and `distance` must be numeric. (The
+        // registry-sync check that these keys match the real tool params lives in
+        // geolibre-cli, which can build the whitebox registry.)
+        let map = whitebox_param_schema_overrides("spatial_join")
+            .expect("missing spatial_join override");
+        let keys: std::collections::BTreeSet<_> = map.keys().map(String::as_str).collect();
+        let expected: std::collections::BTreeSet<_> =
+            ["target", "join", "predicate", "distance", "strategy", "prefix", "output"]
+                .into_iter()
+                .collect();
+        assert_eq!(keys, expected);
+        assert!(whitebox_param_schema_overrides("definitely_not_a_tool").is_none());
     }
 }

--- a/crates/geolibre-tools/src/lib.rs
+++ b/crates/geolibre-tools/src/lib.rs
@@ -212,59 +212,6 @@ pub fn geolibre_param_schemas(tool_id: &str) -> Option<BTreeMap<String, ToolPara
     Some(map)
 }
 
-/// Curated parameter-schema corrections for a handful of upstream
-/// `whitebox_next_gen` tools that wbcore's name/description-based inference
-/// mis-types.
-///
-/// These tools are *not* GeoLibre-authored, so they don't appear in
-/// [`geolibre_param_schemas`]; but their inferred schemas are wrong enough to
-/// break a host UI. `spatial_join`, for instance, infers its `target`/`join`
-/// layer paths as plain strings (so a UI renders a text box instead of a file
-/// picker), its numeric `distance` as a string, and its `strategy` enum as a
-/// LiDAR input file. Supplying explicit schemas here lets the manifest emitter
-/// hand consumers an accurate `io_role`/`data_kind`/`schema` for each param.
-///
-/// Keep this list small and evidence-driven: only override a tool whose
-/// inferred schema is demonstrably wrong, and mirror the param order and option
-/// lists the tool documents in its own descriptions.
-pub fn whitebox_param_schema_overrides(
-    tool_id: &str,
-) -> Option<BTreeMap<String, ToolParamSchema>> {
-    let vector_in = ToolParamSchema::input_vector_any;
-    let vector_out = ToolParamSchema::output_vector_any;
-    let float = ToolParamSchema::scalar_float;
-
-    let map = match tool_id {
-        "spatial_join" => schemas(&[
-            ("target", vector_in()),
-            ("join", vector_in()),
-            (
-                "predicate",
-                ToolParamSchema::enum_values(&[
-                    "intersects",
-                    "within",
-                    "contains",
-                    "touches",
-                    "crosses",
-                    "overlaps",
-                    "within_distance",
-                ]),
-            ),
-            ("distance", float()),
-            (
-                "strategy",
-                ToolParamSchema::enum_values(&[
-                    "first", "last", "count", "sum", "mean", "min", "max",
-                ]),
-            ),
-            ("prefix", ToolParamSchema::string()),
-            ("output", vector_out()),
-        ]),
-        _ => return None,
-    };
-    Some(map)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -297,22 +244,5 @@ mod tests {
                 );
             }
         }
-    }
-
-    #[test]
-    fn spatial_join_override_has_typed_inputs() {
-        // Guard the curated correction: the layer paths must be file inputs, the
-        // enums must carry their options, and `distance` must be numeric. (The
-        // registry-sync check that these keys match the real tool params lives in
-        // geolibre-cli, which can build the whitebox registry.)
-        let map = whitebox_param_schema_overrides("spatial_join")
-            .expect("missing spatial_join override");
-        let keys: std::collections::BTreeSet<_> = map.keys().map(String::as_str).collect();
-        let expected: std::collections::BTreeSet<_> =
-            ["target", "join", "predicate", "distance", "strategy", "prefix", "output"]
-                .into_iter()
-                .collect();
-        assert_eq!(keys, expected);
-        assert!(whitebox_param_schema_overrides("definitely_not_a_tool").is_none());
     }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -197,6 +197,43 @@
         return { kind, hint: v, options, scalar, primary: p.name === "input" };
       }
 
+      // Some params only make sense for one choice of a sibling enum — e.g.
+      // spatial_join's `distance` applies only "for within_distance predicate".
+      // Detect that dependency from the param's own description and return
+      // { controller, value } so the field can be hidden until the controlling
+      // enum selects that value. Conservative: only fires when the description
+      // names a value that an actual sibling enum param offers.
+      function conditionFor(tool, p, params) {
+        const m = (p.description || "").match(
+          /\bfor\s+(?:the\s+)?'?([a-z][a-z0-9_]*)'?\s+(?:predicate|mode|method|strategy|option|type)\b/i,
+        );
+        if (!m) return null;
+        const value = m[1].toLowerCase();
+        const controller = params.find((q) => {
+          if (q.name === p.name) return false;
+          const c = classify(tool, q);
+          return c.kind === "enum" && (c.options || []).some((o) => String(o).toLowerCase() === value);
+        });
+        return controller ? { controller: controller.name, value } : null;
+      }
+
+      // Hide any field whose `data-show-when` controller doesn't currently hold
+      // its `data-show-value`. Hidden fields are skipped when building the
+      // command/invocation and the permalink, so an irrelevant flag never rides
+      // along.
+      function applyConditions() {
+        const form = $("form");
+        if (!form) return;
+        form.querySelectorAll(".field[data-show-when]").forEach((field) => {
+          const ctl = form.querySelector(`[data-name="${field.dataset.showWhen}"]`);
+          const on = !!ctl && String(ctl.value) === field.dataset.showValue;
+          field.hidden = !on;
+        });
+      }
+
+      // A control counts only when its enclosing field is visible.
+      const fieldVisible = (el) => !el.closest(".field")?.hidden;
+
       function renderList() {
         const f = $("filter").value.trim().toLowerCase();
         const cat = $("category").value;
@@ -247,7 +284,7 @@
           const form = $("form");
           if (form) {
             form.querySelectorAll("[data-name]").forEach((el) => {
-              if (el.dataset.kind === "file") return;
+              if (el.dataset.kind === "file" || !fieldVisible(el)) return;
               const def = el.dataset.default ?? "";
               const val = el.dataset.kind === "bool" ? (el.checked ? "true" : "false") : String(el.value);
               if (val !== def) params.set(el.dataset.name, val);
@@ -281,6 +318,7 @@
           const extra = form.querySelector("[data-extra]");
           if (extra) extra.value = params.get("args");
         }
+        applyConditions();
         updateCmd();
       }
 
@@ -339,7 +377,11 @@
             } else {
               control = `<input type="text" id="${id}" data-name="${p.name}" data-kind="text" data-default="${esc(c.hint ?? "")}" value="${esc(c.hint ?? "")}" />`;
             }
-            return `<div class="field"><label for="${id}">${esc(p.name)}${req}</label>${desc}${control}</div>`;
+            const cond = conditionFor(t, p, params);
+            const condAttr = cond
+              ? ` data-show-when="${esc(cond.controller)}" data-show-value="${esc(cond.value)}"`
+              : "";
+            return `<div class="field"${condAttr}><label for="${id}">${esc(p.name)}${req}</label>${desc}${control}</div>`;
           })
           .join("");
 
@@ -368,11 +410,13 @@
           el.addEventListener("change", onFormChange);
         });
         $("run").addEventListener("click", run);
+        applyConditions();
         updateCmd();
       }
 
       // Reflect form edits into both the command preview and the shareable URL.
       function onFormChange() {
+        applyConditions();
         updateCmd();
         writePermalink();
       }
@@ -384,6 +428,7 @@
         const outputs = [];
         const controls = $("form").querySelectorAll("[data-name]");
         for (const el of controls) {
+          if (!fieldVisible(el)) continue; // a hidden, condition-gated field
           const name = el.dataset.name;
           const kind = el.dataset.kind;
           if (kind === "file") {


### PR DESCRIPTION
Fixes the broken tool inputs reported in #17 (spatial_join example).

## Root cause

`spatial_join` is an upstream `whitebox_next_gen` tool, so its per-param schema came from wbcore's name/description-based inference, which mis-typed several params. The demo renders controls straight from that schema, so:

- `target` / `join` (layer paths) were inferred as plain strings, so they rendered as free-form text boxes instead of file pickers.
- `distance` was inferred as a string, so it rendered as text instead of a number input.
- `strategy` was inferred as a LiDAR input file, so it rendered as a file picker instead of a select.
- only `predicate` rendered correctly (its options were parsed from the description).

## Fix

1. Add `whitebox_param_schema_overrides()` in `geolibre-tools` with a curated, evidence-driven schema for `spatial_join`, and consult it from the manifest emitter (`enriched_manifest`) after the GeoLibre-authored schemas. This corrects the manifest for every consumer (web demo, JS, Python), not just the demo. `predicate` and `strategy` now carry their full option lists; `target`/`join`/`output` are vector I/O; `distance` is numeric.

2. Add conditional field visibility to the demo. A field whose description ties it to a single value of a sibling enum (e.g. `distance`, "Distance threshold for within_distance predicate") is hidden until that value is selected, and is omitted from both the generated command and the shareable permalink while hidden.

## Verification

- `cargo test -p geolibre-cli -p geolibre-tools` passes, including new tests that assert the override keys match the real tool params and that the enriched manifest renders file/enum/number/output controls correctly.
- Drove the real `demo/index.html` in a headless browser (stubbed runner): `target`/`join` are file inputs, `predicate`/`strategy` are selects with the right options, `distance` is a number input that is hidden for `predicate=intersects` and shown for `predicate=within_distance`, and the generated command includes `--distance` only when the field is visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conditional form fields in the demo so some inputs appear only when related options are selected.
  * Improved tool parameter handling for clearer input types, including vector inputs, numeric values, and option lists.

* **Bug Fixes**
  * Permalink generation now skips hidden conditional fields, so shared links include only relevant inputs.
  * Command previews and tool runs now ignore hidden fields, keeping displayed commands and executed settings in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->