### PR TITLE
feat(tools): h3_to_vector and h3_polyfill — finish H3 DGGS toolset (#22)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28a80e3145d8ad11ba0995949bbcf48b9df2be62772b3d351ef017dff6ecb853"
 
 [[package]]
+name = "float_next_after"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37007738a80ea34f969af54a3390dd72cacdef654974cfd449c9f6f72dbaac10"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +734,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30eb1fdc57c1e5cfd11826fe0caec4b9dc7901f3758263bb506228d88c8d9e9a"
+dependencies = [
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "i_overlay",
+ "log",
+ "num-traits",
+ "rand 0.10.1",
+ "rand_pcg",
+ "robust",
+ "rstar",
+ "sif-itree",
+]
+
+[[package]]
+name = "geo-traits"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7c353d12a704ccfab1ba8bfb1a7fe6cb18b665bf89d37f4f7890edcd260206"
+
+[[package]]
+name = "geo-types"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
+dependencies = [
+ "approx",
+ "num-traits",
+ "rstar",
+ "serde",
+]
+
+[[package]]
+name = "geographiclib-rs"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "geolibre-cli"
 version = "0.4.3"
 dependencies = [
@@ -742,6 +794,7 @@ name = "geolibre-tools"
 version = "0.4.3"
 dependencies = [
  "flate2",
+ "geo",
  "h3o",
  "parquet",
  "png 0.17.16",
@@ -933,6 +986,8 @@ dependencies = [
  "ahash",
  "either",
  "float_eq",
+ "geo",
+ "geo-traits",
  "h3o-bit",
  "libm",
  "ordered-float 5.3.0",
@@ -957,6 +1012,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,6 +1036,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1056,48 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "i_float"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "813145bb0ad5b60f55cbbf3c74cdceda1c0a9d253b35c4cc36ae0df7887cb78f"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "i_key_sort"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d73d122b937fca067feb0ad74f62388920272b27c356d4df2d0cfdd59e044cf0"
+
+[[package]]
+name = "i_overlay"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd314b4668e2b3a12508f2e125558c82a6c0a8636fa5107a900f79ce414e450"
+dependencies = [
+ "i_float",
+ "i_key_sort",
+ "i_shape",
+ "i_tree",
+]
+
+[[package]]
+name = "i_shape"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa9eac533d7509a8ab87672b60ac610c17240f9ea4851d26227689fdfe349c8"
+dependencies = [
+ "i_float",
+]
+
+[[package]]
+name = "i_tree"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4804bdc1dc124eb7e1aa9e144ecc04096bcf787a10a15fa44af682b51f0f6cce"
 
 [[package]]
 name = "iana-time-zone"
@@ -2142,6 +2258,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,6 +2367,17 @@ name = "robust"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
+]
 
 [[package]]
 name = "rustc_version"
@@ -2422,6 +2558,12 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "sif-itree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
 
 [[package]]
 name = "simba"

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -25,6 +25,12 @@ serde_json = "1"
 png = "0.17"
 # Pure-Rust gzip (miniz_oxide backend) for the PMTiles directory + metadata.
 flate2 = "1"
-# Pure-Rust H3 (no C deps); powers the vector_to_h3 DGGS-binning tool. Verified
-# to compile for both wasm32-unknown-unknown and wasm32-wasip1.
-h3o = "0.10.0"
+# Pure-Rust H3 (no C deps); powers the vector_to_h3 / h3_to_vector / h3_polyfill
+# DGGS tools. Verified to compile for both wasm32-unknown-unknown and
+# wasm32-wasip1. The `geo` feature pulls the pure-Rust `geo` crate and enables
+# the polygon tiler (h3o::geom) used by h3_polyfill.
+h3o = { version = "0.10.0", features = ["geo"] }
+# Geometry types for building polygons handed to h3o's tiler. Pinned to the same
+# minor `geo` uses internally so the `geo::Polygon` types unify (no duplicate
+# geo crate in the graph). Pure Rust, compiles to the wasm targets.
+geo = { version = "0.33", default-features = false }

--- a/crates/geolibre-tools/src/h3_polyfill.rs
+++ b/crates/geolibre-tools/src/h3_polyfill.rs
@@ -1,0 +1,311 @@
+//! GeoLibre tool: cover polygons with H3 cells (polyfill).
+//!
+//! For each polygon in the input layer, finds the H3 cells at a chosen
+//! resolution that cover it and emits one polygon per distinct cell with its
+//! `h3` index. Coverage uses [`ContainmentMode::Covers`], so the returned cells
+//! fully blanket each input polygon (the complete-coverage choice, as opposed to
+//! centroid-only binning).
+//!
+//! This complements [`crate::vector_to_h3`] (which bins features *into* cells by
+//! a representative point): polyfill instead tiles an *area* with cells, the H3
+//! analogue of a polygon-to-grid overlay.
+//!
+//! H3 work is done by [`h3o`](https://docs.rs/h3o) (pure Rust, no C deps); the
+//! polygon tiler lives behind its `geo` feature. See issue #22.
+
+use std::collections::BTreeSet;
+
+use h3o::geom::{ContainmentMode, TilerBuilder};
+use h3o::{CellIndex, Resolution};
+use serde_json::{json, Value};
+use wbcore::{
+    LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata, ToolParamSpec,
+    ToolRunResult,
+};
+use wbvector::{Coord, FieldDef, FieldType, FieldValue, Geometry, GeometryType, Layer, Ring};
+
+use crate::vector_common::{load_input_layer, parse_optional_str, write_or_store_layer};
+
+/// Default H3 resolution (see [`crate::vector_to_h3`]); 8 is ~0.7 km² cells.
+const DEFAULT_RESOLUTION: u8 = 8;
+
+/// Covers input polygons with H3 cells at a chosen resolution.
+pub struct H3PolyfillTool;
+
+impl Tool for H3PolyfillTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "h3_polyfill",
+            display_name: "H3 Polyfill",
+            summary: "Cover input polygons with H3 discrete-global-grid cells at a chosen resolution.",
+            category: ToolCategory::Conversion,
+            license_tier: LicenseTier::Open,
+            params: vec![
+                ToolParamSpec {
+                    name: "input",
+                    description: "Input polygon vector file path (must be geographic lon/lat, EPSG:4326) or in-memory handle.",
+                    required: true,
+                },
+                ToolParamSpec {
+                    name: "output",
+                    description: "Output vector path; the driver is taken from its extension (.geojson, .fgb, .parquet, ...). If omitted, the layer is stored in memory.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "resolution",
+                    description: "H3 resolution 0 (coarsest) to 15 (finest); default 8 (~0.7 km² cells).",
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        if args
+            .get("input")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .unwrap_or("")
+            .is_empty()
+        {
+            return Err(ToolError::Validation(
+                "missing required string parameter 'input'".to_string(),
+            ));
+        }
+        if let Some(res) = parse_optional_resolution(args)? {
+            Resolution::try_from(res).map_err(|_| {
+                ToolError::Validation(format!("'resolution' must be 0-15, got {res}"))
+            })?;
+        }
+        Ok(())
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = args.get("input").and_then(Value::as_str).ok_or_else(|| {
+            ToolError::Validation("missing required parameter 'input'".to_string())
+        })?;
+        let output = parse_optional_str(args, "output")?;
+        let res_u8 = parse_optional_resolution(args)?.unwrap_or(DEFAULT_RESOLUTION);
+        let resolution = Resolution::try_from(res_u8).map_err(|_| {
+            ToolError::Validation(format!("'resolution' must be 0-15, got {res_u8}"))
+        })?;
+
+        ctx.progress.info("reading input vector");
+        let layer = load_input_layer(input)?;
+        // H3 indexes geographic coordinates; refuse a non-4326 CRS rather than
+        // silently producing garbage cells. A missing CRS is assumed to be 4326.
+        if let Some(epsg) = layer.crs_epsg() {
+            if epsg != 4326 {
+                return Err(ToolError::Validation(format!(
+                    "input CRS is EPSG:{epsg}; reproject to EPSG:4326 (lon/lat) before H3 polyfill"
+                )));
+            }
+        }
+        let feature_count = layer.len();
+
+        ctx.progress.info("covering polygons with H3 cells");
+        let mut cells: BTreeSet<u64> = BTreeSet::new();
+        let mut skipped = 0u64;
+        for feature in layer.iter() {
+            let Some(geom) = feature.geometry.as_ref() else {
+                skipped += 1;
+                continue;
+            };
+            let polys = geo_polygons(geom);
+            if polys.is_empty() {
+                skipped += 1; // not an areal geometry
+                continue;
+            }
+            for poly in polys {
+                // A degenerate/invalid ring fails to tile; skip it rather than
+                // aborting the whole run.
+                let mut tiler = TilerBuilder::new(resolution)
+                    .containment_mode(ContainmentMode::Covers)
+                    .build();
+                if tiler.add(poly).is_err() {
+                    skipped += 1;
+                    continue;
+                }
+                cells.extend(tiler.into_coverage().map(u64::from));
+            }
+        }
+
+        ctx.progress.info("building H3 cell polygons");
+        let mut out = Layer::new("h3_polyfill")
+            .with_geom_type(GeometryType::Polygon)
+            .with_crs_epsg(4326);
+        out.add_field(FieldDef::new("h3", FieldType::Text));
+        for &cell_raw in &cells {
+            let cell = CellIndex::try_from(cell_raw)
+                .map_err(|e| ToolError::Execution(format!("invalid H3 cell: {e}")))?;
+            out.add_feature(
+                Some(Geometry::polygon(cell_polygon_ring(cell), Vec::new())),
+                &[("h3", FieldValue::Text(cell.to_string()))],
+            )
+            .map_err(|e| ToolError::Execution(format!("failed building H3 feature: {e}")))?;
+        }
+
+        ctx.progress.info("writing output vector");
+        let out_path = write_or_store_layer(out, output)?;
+
+        let mut outputs = std::collections::BTreeMap::new();
+        outputs.insert("output".to_string(), json!(out_path));
+        outputs.insert("resolution".to_string(), json!(res_u8));
+        outputs.insert("feature_count".to_string(), json!(feature_count));
+        outputs.insert("cell_count".to_string(), json!(cells.len()));
+        outputs.insert("skipped".to_string(), json!(skipped));
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+/// Parses the optional `resolution` parameter (a JSON number or numeric string).
+fn parse_optional_resolution(args: &ToolArgs) -> Result<Option<u8>, ToolError> {
+    match args.get("resolution") {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(s)) if s.trim().is_empty() => Ok(None),
+        Some(Value::String(s)) => s.trim().parse::<u8>().map(Some).map_err(|_| {
+            ToolError::Validation(format!("'resolution' must be an integer, got '{s}'"))
+        }),
+        Some(Value::Number(n)) => n
+            .as_u64()
+            .filter(|v| *v <= u8::MAX as u64)
+            .map(|v| Some(v as u8))
+            .ok_or_else(|| {
+                ToolError::Validation("'resolution' must be an integer 0-15".to_string())
+            }),
+        Some(_) => Err(ToolError::Validation(
+            "'resolution' must be a number when provided".to_string(),
+        )),
+    }
+}
+
+/// Converts an input geometry into the `geo::Polygon`s the tiler accepts. Only
+/// (multi)polygons contribute; point/line geometries yield an empty list and
+/// are counted as skipped by the caller.
+fn geo_polygons(geom: &Geometry) -> Vec<geo::Polygon> {
+    match geom {
+        Geometry::Polygon {
+            exterior,
+            interiors,
+        } => vec![to_geo_polygon(exterior, interiors)],
+        Geometry::MultiPolygon(polys) => polys
+            .iter()
+            .map(|(ext, holes)| to_geo_polygon(ext, holes))
+            .collect(),
+        Geometry::GeometryCollection(geoms) => geoms.iter().flat_map(geo_polygons).collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn to_geo_polygon(exterior: &Ring, interiors: &[Ring]) -> geo::Polygon {
+    geo::Polygon::new(
+        ring_to_linestring(exterior),
+        interiors.iter().map(ring_to_linestring).collect(),
+    )
+}
+
+fn ring_to_linestring(ring: &Ring) -> geo::LineString {
+    // `geo::Polygon::new` closes rings itself, so the missing closing vertex in
+    // `Ring` is fine.
+    geo::LineString::new(
+        ring.coords()
+            .iter()
+            .map(|c| geo::Coord { x: c.x, y: c.y })
+            .collect(),
+    )
+}
+
+/// Builds the exterior ring (lon/lat coordinates) of an H3 cell's boundary,
+/// without the closing duplicate vertex (matching `Ring`).
+fn cell_polygon_ring(cell: CellIndex) -> Vec<Coord> {
+    cell.boundary()
+        .iter()
+        .map(|ll| Coord::xy(ll.lng(), ll.lat()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+    use wbcore::{AllowAllCapabilities, ProgressSink};
+
+    struct NullProgress;
+    impl ProgressSink for NullProgress {}
+
+    fn ctx() -> ToolContext<'static> {
+        ToolContext {
+            progress: &NullProgress,
+            capabilities: &AllowAllCapabilities,
+        }
+    }
+
+    /// A ~0.2° square around San Francisco (lon/lat), CCW, unclosed ring.
+    fn square_layer() -> Layer {
+        let mut l = Layer::new("poly")
+            .with_geom_type(GeometryType::Polygon)
+            .with_crs_epsg(4326);
+        let ring = vec![
+            Coord::xy(-122.5, 37.7),
+            Coord::xy(-122.3, 37.7),
+            Coord::xy(-122.3, 37.9),
+            Coord::xy(-122.5, 37.9),
+        ];
+        l.add_feature(Some(Geometry::polygon(ring, Vec::new())), &[])
+            .unwrap();
+        l
+    }
+
+    #[test]
+    fn covers_polygon_with_cells() {
+        let id = wbvector::memory_store::put_vector(square_layer());
+        let input = wbvector::memory_store::make_vector_memory_path(&id);
+        let args: ToolArgs =
+            serde_json::from_value(json!({ "input": input, "resolution": "7" })).unwrap();
+
+        let result = H3PolyfillTool.run(&args, &ctx()).unwrap();
+        assert_eq!(result.outputs["feature_count"], json!(1));
+        assert_eq!(result.outputs["skipped"], json!(0));
+        let n = result.outputs["cell_count"].as_u64().unwrap();
+        assert!(n > 1, "a ~0.2-degree square should need many res-7 cells, got {n}");
+
+        let out = load_input_layer(result.outputs["output"].as_str().unwrap()).unwrap();
+        assert_eq!(out.len() as u64, n);
+        assert_eq!(out.geom_type, Some(GeometryType::Polygon));
+        // Every output cell id parses back to a res-7 cell.
+        let hidx = out.schema.field_index("h3").unwrap();
+        for f in out.iter() {
+            let id = f.attributes[hidx].as_str().unwrap();
+            let cell = h3o::CellIndex::from_str(id).unwrap();
+            assert_eq!(cell.resolution(), Resolution::Seven);
+        }
+    }
+
+    #[test]
+    fn finer_resolution_yields_more_cells() {
+        let run = |res: &str| {
+            let id = wbvector::memory_store::put_vector(square_layer());
+            let input = wbvector::memory_store::make_vector_memory_path(&id);
+            let args: ToolArgs =
+                serde_json::from_value(json!({ "input": input, "resolution": res })).unwrap();
+            H3PolyfillTool.run(&args, &ctx()).unwrap().outputs["cell_count"]
+                .as_u64()
+                .unwrap()
+        };
+        assert!(run("8") > run("6"), "finer resolution must yield more cells");
+    }
+
+    #[test]
+    fn non_polygon_features_are_skipped() {
+        let mut l = Layer::new("pts")
+            .with_geom_type(GeometryType::Point)
+            .with_crs_epsg(4326);
+        l.add_feature(Some(Geometry::point(-122.4, 37.8)), &[]).unwrap();
+        let id = wbvector::memory_store::put_vector(l);
+        let input = wbvector::memory_store::make_vector_memory_path(&id);
+        let args: ToolArgs = serde_json::from_value(json!({ "input": input })).unwrap();
+        let r = H3PolyfillTool.run(&args, &ctx()).unwrap();
+        assert_eq!(r.outputs["skipped"], json!(1));
+        assert_eq!(r.outputs["cell_count"], json!(0));
+    }
+}

--- a/crates/geolibre-tools/src/h3_to_vector.rs
+++ b/crates/geolibre-tools/src/h3_to_vector.rs
@@ -1,0 +1,234 @@
+//! GeoLibre tool: turn H3 cell IDs into cell-boundary polygons.
+//!
+//! The inverse of [`crate::vector_to_h3`]: given a layer whose features carry an
+//! H3 cell id in a text field (for example a CSV/table of ids, or the output of
+//! `vector_to_h3`), emit one polygon per feature tracing that cell's boundary.
+//! All of the input's other attributes are copied through unchanged, so a
+//! `count`/value column rides along for rendering or joins.
+//!
+//! H3 work is done by [`h3o`](https://docs.rs/h3o), a pure-Rust reimplementation
+//! of H3 with no C dependencies, so it compiles to the same wasm targets as the
+//! rest of the suite. See issue #22.
+
+use std::collections::BTreeMap;
+use std::str::FromStr;
+
+use h3o::CellIndex;
+use serde_json::{json, Value};
+use wbcore::{
+    LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata, ToolParamSpec,
+    ToolRunResult,
+};
+use wbvector::{Coord, FieldDef, FieldType, FieldValue, Geometry, GeometryType, Layer};
+
+use crate::vector_common::{load_input_layer, parse_optional_str, write_or_store_layer};
+
+/// Default name of the field holding the H3 cell id.
+const DEFAULT_FIELD: &str = "h3";
+
+/// Builds H3 cell-boundary polygons from a column of H3 cell ids.
+pub struct H3ToVectorTool;
+
+impl Tool for H3ToVectorTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "h3_to_vector",
+            display_name: "H3 Cells to Polygons",
+            summary: "Turn a column of H3 cell ids into cell-boundary polygons, copying other attributes through.",
+            category: ToolCategory::Conversion,
+            license_tier: LicenseTier::Open,
+            params: vec![
+                ToolParamSpec {
+                    name: "input",
+                    description: "Input vector file path (or in-memory handle) with a field of H3 cell ids.",
+                    required: true,
+                },
+                ToolParamSpec {
+                    name: "output",
+                    description: "Output vector path; the driver is taken from its extension (.geojson, .fgb, .parquet, ...). If omitted, the layer is stored in memory.",
+                    required: false,
+                },
+                ToolParamSpec {
+                    name: "field",
+                    description: "Name of the text field holding the H3 cell id; default 'h3'.",
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        if args
+            .get("input")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .unwrap_or("")
+            .is_empty()
+        {
+            return Err(ToolError::Validation(
+                "missing required string parameter 'input'".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = args.get("input").and_then(Value::as_str).ok_or_else(|| {
+            ToolError::Validation("missing required parameter 'input'".to_string())
+        })?;
+        let output = parse_optional_str(args, "output")?;
+        let field = parse_optional_str(args, "field")?.unwrap_or(DEFAULT_FIELD);
+
+        ctx.progress.info("reading input vector");
+        let layer = load_input_layer(input)?;
+        let field_idx = layer.schema.field_index(field).ok_or_else(|| {
+            ToolError::Validation(format!("input has no field '{field}' to read H3 ids from"))
+        })?;
+        let feature_count = layer.len();
+
+        // Copy the input schema so every attribute rides along with the cell.
+        let mut out = Layer::new("h3_cells")
+            .with_geom_type(GeometryType::Polygon)
+            .with_crs_epsg(4326);
+        for def in layer.schema.fields() {
+            out.add_field(def.clone());
+        }
+        // Guarantee an `h3` text column exists for the canonical id, even when the
+        // source field is named something else.
+        let h3_out = if layer.schema.field_index(DEFAULT_FIELD).is_some() {
+            DEFAULT_FIELD
+        } else {
+            out.add_field(FieldDef::new(DEFAULT_FIELD, FieldType::Text));
+            DEFAULT_FIELD
+        };
+
+        ctx.progress.info("building H3 cell polygons");
+        let mut skipped = 0u64;
+        for feature in layer.iter() {
+            let Some(id) = feature.attributes.get(field_idx).and_then(FieldValue::as_str) else {
+                skipped += 1;
+                continue;
+            };
+            let Ok(cell) = CellIndex::from_str(id.trim()) else {
+                skipped += 1; // not a valid H3 id
+                continue;
+            };
+            // Carry every source attribute through, then set the canonical id.
+            let mut attrs: Vec<(&str, FieldValue)> = layer
+                .schema
+                .fields()
+                .iter()
+                .enumerate()
+                .map(|(i, def)| (def.name.as_str(), feature.attributes[i].clone()))
+                .collect();
+            attrs.push((h3_out, FieldValue::Text(cell.to_string())));
+
+            out.add_feature(
+                Some(Geometry::polygon(cell_polygon_ring(cell), Vec::new())),
+                &attrs,
+            )
+            .map_err(|e| ToolError::Execution(format!("failed building H3 feature: {e}")))?;
+        }
+
+        ctx.progress.info("writing output vector");
+        let out_path = write_or_store_layer(out, output)?;
+
+        let mut outputs = BTreeMap::new();
+        outputs.insert("output".to_string(), json!(out_path));
+        outputs.insert("feature_count".to_string(), json!(feature_count));
+        outputs.insert("skipped".to_string(), json!(skipped));
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+/// Builds the exterior ring (lon/lat coordinates) of an H3 cell's boundary,
+/// without the closing duplicate vertex (matching `Ring`).
+fn cell_polygon_ring(cell: CellIndex) -> Vec<Coord> {
+    cell.boundary()
+        .iter()
+        .map(|ll| Coord::xy(ll.lng(), ll.lat()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wbcore::{AllowAllCapabilities, ProgressSink};
+
+    struct NullProgress;
+    impl ProgressSink for NullProgress {}
+
+    fn ctx() -> ToolContext<'static> {
+        ToolContext {
+            progress: &NullProgress,
+            capabilities: &AllowAllCapabilities,
+        }
+    }
+
+    /// A small layer of H3 ids (San Francisco and Paris at res 8) plus a value.
+    fn ids_layer() -> Layer {
+        let mut l = Layer::new("ids").with_geom_type(GeometryType::Point);
+        l.add_field(FieldDef::new("h3", FieldType::Text));
+        l.add_field(FieldDef::new("count", FieldType::Integer));
+        let sf = h3o::LatLng::new(37.7749, -122.4194)
+            .unwrap()
+            .to_cell(h3o::Resolution::Eight);
+        let paris = h3o::LatLng::new(48.8566, 2.3522)
+            .unwrap()
+            .to_cell(h3o::Resolution::Eight);
+        l.add_feature(None, &[("h3", FieldValue::Text(sf.to_string())), ("count", FieldValue::Integer(2))])
+            .unwrap();
+        l.add_feature(None, &[("h3", FieldValue::Text(paris.to_string())), ("count", FieldValue::Integer(1))])
+            .unwrap();
+        l
+    }
+
+    #[test]
+    fn builds_cell_polygons_and_copies_attributes() {
+        let id = wbvector::memory_store::put_vector(ids_layer());
+        let input = wbvector::memory_store::make_vector_memory_path(&id);
+        let args: ToolArgs = serde_json::from_value(json!({ "input": input })).unwrap();
+
+        let result = H3ToVectorTool.run(&args, &ctx()).unwrap();
+        assert_eq!(result.outputs["feature_count"], json!(2));
+        assert_eq!(result.outputs["skipped"], json!(0));
+
+        let out = load_input_layer(result.outputs["output"].as_str().unwrap()).unwrap();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out.geom_type, Some(GeometryType::Polygon));
+        // The `count` attribute is carried through unchanged.
+        let cidx = out.schema.field_index("count").unwrap();
+        let total: i64 = out.iter().map(|f| f.attributes[cidx].as_i64().unwrap()).sum();
+        assert_eq!(total, 3);
+        // Each cell boundary is a hexagon/pentagon: >= 5 vertices.
+        for f in out.iter() {
+            match &f.geometry {
+                Some(Geometry::Polygon { exterior, .. }) => assert!(exterior.len() >= 5),
+                _ => panic!("expected polygon geometry"),
+            }
+        }
+    }
+
+    #[test]
+    fn skips_invalid_ids_and_errors_on_missing_field() {
+        // Missing field -> validation error.
+        let mut l = Layer::new("x").with_geom_type(GeometryType::Point);
+        l.add_field(FieldDef::new("name", FieldType::Text));
+        l.add_feature(None, &[("name", FieldValue::Text("nope".into()))]).unwrap();
+        let id = wbvector::memory_store::put_vector(l);
+        let input = wbvector::memory_store::make_vector_memory_path(&id);
+        let args: ToolArgs = serde_json::from_value(json!({ "input": input })).unwrap();
+        assert!(H3ToVectorTool.run(&args, &ctx()).is_err());
+
+        // Present field but unparsable value -> skipped, not an error.
+        let mut l2 = Layer::new("y").with_geom_type(GeometryType::Point);
+        l2.add_field(FieldDef::new("h3", FieldType::Text));
+        l2.add_feature(None, &[("h3", FieldValue::Text("not-an-h3-id".into()))]).unwrap();
+        let id2 = wbvector::memory_store::put_vector(l2);
+        let input2 = wbvector::memory_store::make_vector_memory_path(&id2);
+        let args2: ToolArgs = serde_json::from_value(json!({ "input": input2 })).unwrap();
+        let r = H3ToVectorTool.run(&args2, &ctx()).unwrap();
+        assert_eq!(r.outputs["skipped"], json!(1));
+        assert_eq!(load_input_layer(r.outputs["output"].as_str().unwrap()).unwrap().len(), 0);
+    }
+}

--- a/crates/geolibre-tools/src/lib.rs
+++ b/crates/geolibre-tools/src/lib.rs
@@ -14,6 +14,8 @@ mod dem_filter;
 mod extract_sinks;
 mod fill;
 mod geoparquet_io;
+mod h3_polyfill;
+mod h3_to_vector;
 mod hilbert;
 mod polygonize;
 mod pmtiles;
@@ -61,6 +63,8 @@ pub fn geolibre_tools() -> Vec<Box<dyn Tool>> {
         Box::new(spectral_index::SpectralIndexTool),
         Box::new(vector_convert::VectorConvertTool),
         Box::new(vector_to_h3::VectorToH3Tool),
+        Box::new(h3_to_vector::H3ToVectorTool),
+        Box::new(h3_polyfill::H3PolyfillTool),
         Box::new(render_vector_png::RenderVectorPngTool),
         Box::new(write_pmtiles::WritePmTilesTool),
     ]
@@ -200,6 +204,16 @@ pub fn geolibre_param_schemas(tool_id: &str) -> Option<BTreeMap<String, ToolPara
         ]),
         "vector_convert" => schemas(&[("input", vector_in()), ("output", vector_out())]),
         "vector_to_h3" => schemas(&[
+            ("input", vector_in()),
+            ("output", vector_out()),
+            ("resolution", int()),
+        ]),
+        "h3_to_vector" => schemas(&[
+            ("input", vector_in()),
+            ("output", vector_out()),
+            ("field", ToolParamSchema::string()),
+        ]),
+        "h3_polyfill" => schemas(&[
             ("input", vector_in()),
             ("output", vector_out()),
             ("resolution", int()),


### PR DESCRIPTION
Completes the H3 DGGS toolset from #22. `vector_to_h3` shipped in #23; this adds the two remaining tools. All pure-Rust via `h3o`, so they compile to the same wasm targets as the rest of the suite.

## Tools

- **`h3_to_vector`** — turn a column of H3 cell ids (a table/list, or the output of `vector_to_h3`) into cell-boundary polygons, copying every other attribute through. Param: `field` (id column, default `h3`).
- **`h3_polyfill`** — cover input polygons with the H3 cells at resolution *R*, using `ContainmentMode::Covers` for complete coverage, deduped across features. Uses `h3o`'s geom tiler behind its `geo` feature; `geo` 0.33 is added (pinned to the version `h3o` uses, so the `geo::Polygon` types unify) to build the polygons handed to the tiler.

Both register in `geolibre_tools()` with explicit param schemas (`input` = vector file, `output` = vector, `resolution` = int / `field` = string), so the demo renders the right controls automatically.

## Verification (real data, cross-checked against canonical `h3-py`)

- **`h3_to_vector`**: round-tripped `vector_to_h3`'s 241 cells over 243 real Natural Earth populated places at res 5, preserving the `count` attribute (sum 243); every output polygon's centroid maps back to its own H3 id at the same resolution (0 mismatches).
- **`h3_polyfill`**: on a real Colorado state polygon, the `Covers` output is **exactly** `h3-py`'s `overlap` polyfill — 171 cells at res 4, 1051 at res 5 — and is correctly bracketed `center ⊆ tool ⊆ overlap`, all cells at the requested resolution.
- Built the WASM runner (with the new `geo` feature) and confirmed both tools run in the **real browser demo**: 750 tools loaded, exit 0, `h3_polyfill` → 1051 cells on Colorado, `h3_to_vector` → 241 features.

`cargo test -p geolibre-cli -p geolibre-tools` passes (37 tests).

Leaves the optional `raster_to_h3` from #22 for a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tool to turn H3 cell IDs in a vector layer into polygon boundaries.
  * Added a tool to generate H3 cell polygons from input polygon features, with configurable resolution.

* **Bug Fixes**
  * Improved validation for input coordinate systems and H3 values, with invalid or unsupported features now safely skipped.
  * Preserved existing attributes when converting H3 cells to vector polygons.

* **Tests**
  * Added coverage for polygon generation, attribute handling, and invalid input cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->