### PR TITLE
fix(deps): bump whitebox-wasm to fix D8 flow tool WASM trap (#28, #29)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "wbcore"
 version = "0.1.1"
-source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
+source = "git+https://github.com/opengeos/whitebox-wasm#77eb302e445cde1278e5d389fa85f0911389b383"
 dependencies = [
  "serde",
  "serde_json",
@@ -3151,7 +3151,7 @@ dependencies = [
 [[package]]
 name = "wbgeotiff"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
+source = "git+https://github.com/opengeos/whitebox-wasm#77eb302e445cde1278e5d389fa85f0911389b383"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -3170,7 +3170,7 @@ dependencies = [
 [[package]]
 name = "wbhdf"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
+source = "git+https://github.com/opengeos/whitebox-wasm#77eb302e445cde1278e5d389fa85f0911389b383"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3181,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "wblidar"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
+source = "git+https://github.com/opengeos/whitebox-wasm#77eb302e445cde1278e5d389fa85f0911389b383"
 dependencies = [
  "rayon",
  "wbhdf",
@@ -3192,7 +3192,7 @@ dependencies = [
 [[package]]
 name = "wbprojection"
 version = "0.3.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
+source = "git+https://github.com/opengeos/whitebox-wasm#77eb302e445cde1278e5d389fa85f0911389b383"
 dependencies = [
  "thiserror 1.0.69",
  "wide 1.5.0",
@@ -3201,7 +3201,7 @@ dependencies = [
 [[package]]
 name = "wbraster"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
+source = "git+https://github.com/opengeos/whitebox-wasm#77eb302e445cde1278e5d389fa85f0911389b383"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "wbspatialstats"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
+source = "git+https://github.com/opengeos/whitebox-wasm#77eb302e445cde1278e5d389fa85f0911389b383"
 dependencies = [
  "log",
  "nalgebra",
@@ -3239,7 +3239,7 @@ dependencies = [
 [[package]]
 name = "wbtools_oss"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
+source = "git+https://github.com/opengeos/whitebox-wasm#77eb302e445cde1278e5d389fa85f0911389b383"
 dependencies = [
  "bincode",
  "chrono",
@@ -3269,7 +3269,7 @@ dependencies = [
 [[package]]
 name = "wbtopology"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
+source = "git+https://github.com/opengeos/whitebox-wasm#77eb302e445cde1278e5d389fa85f0911389b383"
 dependencies = [
  "rayon",
  "robust",
@@ -3279,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "wbvector"
 version = "0.1.4"
-source = "git+https://github.com/opengeos/whitebox-wasm#f723de68211334c280d96a2be7d01a04a73e0722"
+source = "git+https://github.com/opengeos/whitebox-wasm#77eb302e445cde1278e5d389fa85f0911389b383"
 dependencies = [
  "bytes",
  "flatbuffers 24.12.23",


### PR DESCRIPTION
## Summary

Fixes the standalone D8/FD8 flow-routing tools that trapped with a WASM `unreachable` instruction on every input DEM (#28), and exposes the D8 pointer from the composite workflow (#29).

The affected tools live upstream in `opengeos/whitebox-wasm`, so the actual fix landed there (opengeos/whitebox-wasm#3, merged). This PR bumps the git dependency to consume it.

## Root cause (#28)

`d8_pointer`, `d8_flow_accum`, `fd8_flow_accum`, `basins`, and `subbasins` fan work out across rows with `std::thread::spawn`, which is **unsupported on the wasm32 targets we ship** (`wasm32-wasip1` for the WASI runner / Python wheel, `wasm32-unknown-unknown` for the browser lib). At runtime:

```
thread 'main' panicked: failed to spawn thread: Os { code: 58, kind: Unsupported }
wasm trap: wasm `unreachable` instruction executed
```

Because the release profile uses `panic = "abort"`, the panic becomes the `unreachable` trap reported in #28. The fully-serial `flow_accum_full_workflow` was unaffected, which is why it kept working.

## Fix (upstream, consumed here)

[opengeos/whitebox-wasm#3](https://github.com/opengeos/whitebox-wasm/pull/3):
- Adds a `dispatch_worker` helper that spawns a thread on native targets but runs the closure **inline** on wasm32; routes all 11 `thread::spawn` fan-out sites through it. Native multi-threaded performance is unchanged.
- **#29:** adds an `output_pointer` argument to `flow_accum_full_workflow` (alias of the existing `flow_dir_output`), so the accumulation raster and an **ESRI-encodable** D8 pointer (`--esri_pntr`) come from the *same* internal breach pass.

This PR is a one-line `Cargo.lock` bump to `whitebox-wasm@77eb302`.

## Verification

Built `geolibre-cli` for `wasm32-wasip1` against the merged dependency and ran each tool under `wasmtime` on the issue's synthetic DEM:

| tool | before | after |
|------|--------|-------|
| `d8_pointer` | `unreachable` trap (exit 134) | ✅ exit 0 |
| `d8_flow_accum` | `unreachable` trap | ✅ exit 0 |
| `fd8_flow_accum` | `unreachable` trap | ✅ exit 0 |
| `basins` | `unreachable` trap | ✅ exit 0 |
| `subbasins` | trap | ✅ runs (needs `d8_pntr`+`streams`) |
| `flow_accum_full_workflow --output_pointer=… --esri_pntr` | n/a | ✅ writes ESRI pointer + accum from one breach pass |

Output sanity-checked with rasterio: composite accumulation max equals the cell count draining to the single outlet, and pointer values are valid direction codes.

Fixes #28
Fixes #29