### PR TITLE
chore(deps): bump whitebox-wasm for expression/statement param fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "wbcore"
 version = "0.1.1"
-source = "git+https://github.com/opengeos/whitebox-wasm#75716ce0e2593ad461dad43d1a4994c35a7e5350"
+source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
 dependencies = [
  "serde",
  "serde_json",
@@ -3151,7 +3151,7 @@ dependencies = [
 [[package]]
 name = "wbgeotiff"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#75716ce0e2593ad461dad43d1a4994c35a7e5350"
+source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -3170,7 +3170,7 @@ dependencies = [
 [[package]]
 name = "wbhdf"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#75716ce0e2593ad461dad43d1a4994c35a7e5350"
+source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3181,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "wblidar"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#75716ce0e2593ad461dad43d1a4994c35a7e5350"
+source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
 dependencies = [
  "rayon",
  "wbhdf",
@@ -3192,7 +3192,7 @@ dependencies = [
 [[package]]
 name = "wbprojection"
 version = "0.3.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#75716ce0e2593ad461dad43d1a4994c35a7e5350"
+source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
 dependencies = [
  "thiserror 1.0.69",
  "wide 1.5.0",
@@ -3201,7 +3201,7 @@ dependencies = [
 [[package]]
 name = "wbraster"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#75716ce0e2593ad461dad43d1a4994c35a7e5350"
+source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "wbspatialstats"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#75716ce0e2593ad461dad43d1a4994c35a7e5350"
+source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
 dependencies = [
  "log",
  "nalgebra",
@@ -3239,7 +3239,7 @@ dependencies = [
 [[package]]
 name = "wbtools_oss"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#75716ce0e2593ad461dad43d1a4994c35a7e5350"
+source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
 dependencies = [
  "bincode",
  "chrono",
@@ -3269,7 +3269,7 @@ dependencies = [
 [[package]]
 name = "wbtopology"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#75716ce0e2593ad461dad43d1a4994c35a7e5350"
+source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
 dependencies = [
  "rayon",
  "robust",
@@ -3279,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "wbvector"
 version = "0.1.4"
-source = "git+https://github.com/opengeos/whitebox-wasm#75716ce0e2593ad461dad43d1a4994c35a7e5350"
+source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
 dependencies = [
  "bytes",
  "flatbuffers 24.12.23",


### PR DESCRIPTION
## Summary

Bumps the pinned `whitebox-wasm` revs (`wbcore`, `wbtools_oss`, and siblings) to main (`9263574`), which merged [whitebox-wasm#5](https://github.com/opengeos/whitebox-wasm/pull/5): expression/statement parameters are now inferred as free-text strings instead of a bool checkbox / vector input.

## Why

In GeoLibre the Whitebox **Extract By Attribute** (`statement`) and **Field Calculator** (`expression`) tools rendered no expression field, because the enriched manifest inferred those params as a `bool` (checkbox) and a `vector` input (a second layer picker) respectively. See opengeos/GeoLibre#1073.

## Verification

Rebuilt `geolibre-cli` and dumped `manifests`; both params now report `data_kind = string` / `schema.kind = string`:

```
extract_by_attribute.statement | data_kind=string | schema.kind=string
field_calculator.expression    | data_kind=string | schema.kind=string
```

Only `Cargo.lock` changes.
