### PR TITLE
feat(cog): extract COG subsets with CRS reprojection

### DIFF
--- a/crates/geolibre-wasm/src/lib.rs
+++ b/crates/geolibre-wasm/src/lib.rs
@@ -112,6 +112,102 @@ fn bounds_lonlat(epsg: Option<u16>, proj_string: Option<&str>, b: [f64; 4]) -> V
     if any { vec![min_lon, min_lat, max_lon, max_lat] } else { Vec::new() }
 }
 
+fn transform_bbox_between_crs(src: &wbprojection::Crs, dst: &wbprojection::Crs, bbox: &[f64]) -> Result<Vec<f64>, JsValue> {
+    let (min_x, min_y, max_x, max_y) = (bbox[0], bbox[1], bbox[2], bbox[3]);
+    if !(min_x.is_finite() && min_y.is_finite() && max_x.is_finite() && max_y.is_finite())
+        || min_x >= max_x
+        || min_y >= max_y
+    {
+        return Err(JsValue::from_str("bbox must be finite and ordered min < max"));
+    }
+
+    let mut out_min_x = f64::INFINITY;
+    let mut out_min_y = f64::INFINITY;
+    let mut out_max_x = f64::NEG_INFINITY;
+    let mut out_max_y = f64::NEG_INFINITY;
+
+    for i in 0..=8 {
+        let t = i as f64 / 8.0;
+        let x = min_x + (max_x - min_x) * t;
+        let y = min_y + (max_y - min_y) * t;
+        let points = [(x, min_y), (x, max_y), (min_x, y), (max_x, y)];
+        for (px, py) in points {
+            let (tx, ty) = src
+                .transform_to(px, py, dst)
+                .map_err(|e| JsValue::from_str(&format!("bbox reprojection failed: {e}")))?;
+            if tx.is_finite() && ty.is_finite() {
+                out_min_x = out_min_x.min(tx);
+                out_min_y = out_min_y.min(ty);
+                out_max_x = out_max_x.max(tx);
+                out_max_y = out_max_y.max(ty);
+            }
+        }
+    }
+
+    if !out_min_x.is_finite() {
+        return Err(JsValue::from_str("bbox reprojection produced no finite coordinates"));
+    }
+    Ok(vec![out_min_x, out_min_y, out_max_x, out_max_y])
+}
+
+/// Reproject a bbox between two EPSG CRSs.
+///
+/// Input and output order is `[min_x, min_y, max_x, max_y]`. The bbox edges are
+/// densified so projected extrema that fall along an edge are preserved better
+/// than a corner-only transform.
+#[wasm_bindgen]
+pub fn transform_bbox_epsg(src_epsg: u32, dst_epsg: u32, bbox: Vec<f64>) -> Result<Vec<f64>, JsValue> {
+    if bbox.len() != 4 {
+        return Err(JsValue::from_str("bbox must contain [min_x,min_y,max_x,max_y]"));
+    }
+    if src_epsg == dst_epsg {
+        return Ok(bbox);
+    }
+
+    let src = wbprojection::Crs::from_epsg(src_epsg)
+        .map_err(|e| JsValue::from_str(&format!("invalid source EPSG:{src_epsg}: {e}")))?;
+    let dst = wbprojection::Crs::from_epsg(dst_epsg)
+        .map_err(|e| JsValue::from_str(&format!("invalid destination EPSG:{dst_epsg}: {e}")))?;
+
+    transform_bbox_between_crs(&src, &dst, &bbox)
+}
+
+fn transform_points_between_crs(src: &wbprojection::Crs, dst: &wbprojection::Crs, xy: &[f64]) -> Result<Vec<f64>, JsValue> {
+    if xy.len() % 2 != 0 {
+        return Err(JsValue::from_str("coordinates must contain x,y pairs"));
+    }
+    let mut out = Vec::with_capacity(xy.len());
+    for pair in xy.chunks_exact(2) {
+        let x = pair[0];
+        let y = pair[1];
+        if !(x.is_finite() && y.is_finite()) {
+            out.push(f64::NAN);
+            out.push(f64::NAN);
+            continue;
+        }
+        let (tx, ty) = src
+            .transform_to(x, y, dst)
+            .map_err(|e| JsValue::from_str(&format!("point reprojection failed: {e}")))?;
+        out.push(tx);
+        out.push(ty);
+    }
+    Ok(out)
+}
+
+/// Reproject x,y coordinate pairs between two EPSG CRSs.
+#[wasm_bindgen]
+pub fn transform_points_epsg(src_epsg: u32, dst_epsg: u32, xy: Vec<f64>) -> Result<Vec<f64>, JsValue> {
+    if src_epsg == dst_epsg {
+        return Ok(xy);
+    }
+    let src = wbprojection::Crs::from_epsg(src_epsg)
+        .map_err(|e| JsValue::from_str(&format!("invalid source EPSG:{src_epsg}: {e}")))?;
+    let dst = wbprojection::Crs::from_epsg(dst_epsg)
+        .map_err(|e| JsValue::from_str(&format!("invalid destination EPSG:{dst_epsg}: {e}")))?;
+
+    transform_points_between_crs(&src, &dst, &xy)
+}
+
 /// Largest full-raster allocation we will attempt, in bytes. WASM is 32-bit
 /// (4 GiB linear memory) and the input file already occupies part of it, so we
 /// cap whole-raster decodes well below that. Beyond this, callers get a clean
@@ -567,6 +663,9 @@ impl CogStream {
     /// EPSG code of the full-resolution level, if any.
     #[wasm_bindgen(getter)]
     pub fn epsg(&self) -> Option<u32> { self.layout.epsg.map(|e| e as u32) }
+    /// True when the COG CRS is represented by a user-defined projection string.
+    #[wasm_bindgen(getter)]
+    pub fn has_projection_string(&self) -> bool { self.layout.proj_string.is_some() }
     /// No-data sentinel, if declared.
     #[wasm_bindgen(getter)]
     pub fn nodata(&self) -> Option<f64> { self.layout.no_data }
@@ -619,6 +718,40 @@ impl CogStream {
             Some(b) => bounds_lonlat(self.layout.epsg, self.layout.proj_string.as_deref(), b),
             None => Vec::new(),
         }
+    }
+
+    /// Reproject a bbox from `bbox_epsg` into this COG's dataset CRS.
+    ///
+    /// The COG projection string is preferred over its EPSG tag when available,
+    /// because some user-defined projected GeoTIFFs expose only their geographic
+    /// base EPSG code.
+    pub fn bbox_to_dataset_crs(&self, bbox_epsg: u32, bbox: Vec<f64>) -> Result<Vec<f64>, JsValue> {
+        if bbox.len() != 4 {
+            return Err(JsValue::from_str("bbox must contain [min_x,min_y,max_x,max_y]"));
+        }
+        let src = wbprojection::Crs::from_epsg(bbox_epsg)
+            .map_err(|e| JsValue::from_str(&format!("invalid bbox EPSG:{bbox_epsg}: {e}")))?;
+        let dst = lonlat_crs(self.layout.epsg, self.layout.proj_string.as_deref())
+            .ok_or_else(|| JsValue::from_str("COG has no supported CRS"))?;
+        transform_bbox_between_crs(&src, &dst, &bbox)
+    }
+
+    /// Reproject x,y coordinate pairs from an EPSG CRS into this COG's dataset CRS.
+    pub fn points_to_dataset_crs(&self, src_epsg: u32, xy: Vec<f64>) -> Result<Vec<f64>, JsValue> {
+        let src = wbprojection::Crs::from_epsg(src_epsg)
+            .map_err(|e| JsValue::from_str(&format!("invalid source EPSG:{src_epsg}: {e}")))?;
+        let dst = lonlat_crs(self.layout.epsg, self.layout.proj_string.as_deref())
+            .ok_or_else(|| JsValue::from_str("COG has no supported CRS"))?;
+        transform_points_between_crs(&src, &dst, &xy)
+    }
+
+    /// Reproject x,y coordinate pairs from this COG's dataset CRS to an EPSG CRS.
+    pub fn points_from_dataset_crs(&self, dst_epsg: u32, xy: Vec<f64>) -> Result<Vec<f64>, JsValue> {
+        let src = lonlat_crs(self.layout.epsg, self.layout.proj_string.as_deref())
+            .ok_or_else(|| JsValue::from_str("COG has no supported CRS"))?;
+        let dst = wbprojection::Crs::from_epsg(dst_epsg)
+            .map_err(|e| JsValue::from_str(&format!("invalid destination EPSG:{dst_epsg}: {e}")))?;
+        transform_points_between_crs(&src, &dst, &xy)
     }
 
     /// JSON array describing every level: `[{level,width,height,tile_width,

--- a/demo/index.html
+++ b/demo/index.html
@@ -194,7 +194,7 @@
             options = opts;
           }
         }
-        return { kind, hint: v, options, scalar, primary: p.name === "input" };
+        return { kind, hint: v, options, scalar, primary: p.name === "input", sampleDefault: p.schema?.sample_default !== false };
       }
 
       // Some params only make sense for one choice of a sibling enum — e.g.
@@ -348,9 +348,9 @@
             const id = `f_${p.name}`;
             let control;
             if (c.kind === "file") {
-              const note = c.primary ? " (defaults to bundled sample.tif)" : "";
-              control = `<input type="file" id="${id}" data-name="${p.name}" data-kind="file" />` +
-                `<div class="desc">Leave empty to use ${c.primary ? "the sample DEM" : "no file"}${note}.</div>`;
+              const note = c.primary && c.sampleDefault ? " (defaults to bundled sample.tif)" : "";
+              control = `<input type="file" id="${id}" data-name="${p.name}" data-kind="file" data-sample-default="${c.sampleDefault ? "true" : "false"}" />` +
+                `<div class="desc">Leave empty to use ${c.primary && c.sampleDefault ? "the sample DEM" : "no file"}${note}.</div>`;
             } else if (c.kind === "output") {
               const val = outputDefault(t, p, c.hint);
               control = `<input type="text" id="${id}" data-name="${p.name}" data-kind="output" data-default="${esc(val)}" value="${esc(val)}" />`;
@@ -437,7 +437,7 @@
             if (el.files && el.files[0]) {
               fname = el.files[0].name;
               bytes = new Uint8Array(await el.files[0].arrayBuffer());
-            } else if (el.dataset.name === "input" || $("form").querySelector('[data-kind="file"]') === el) {
+            } else if (el.dataset.sampleDefault !== "false" && (el.dataset.name === "input" || $("form").querySelector('[data-kind="file"]') === el)) {
               // primary input: fall back to the bundled sample
               if (!sampleBytes) sampleBytes = new Uint8Array(await (await fetch("./sample.tif")).arrayBuffer());
               if (sampleBytes) { fname = "sample.tif"; bytes = sampleBytes; }

--- a/demo/serve.sh
+++ b/demo/serve.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # Serve the geolibre-rust demo locally.
 #
-# The page (index.html) needs three sibling files at runtime that live elsewhere
-# in the repo: the JS runner and WASI binary from npm/, and a sample DEM from
-# examples/. This script stages them into a temp dir alongside a copy of
-# index.html (with the __BUILD__ cache-busting placeholder filled in), serves
-# that dir over HTTP, and cleans up on exit. The repo's demo/ stays clean.
+# The page (index.html) needs sibling runtime files that live elsewhere in the
+# repo: the JS runner, the WASI binary, the wasm-bindgen browser library from
+# npm/, and a sample DEM from examples/. This script stages them into a temp dir
+# alongside a copy of index.html (with the __BUILD__ cache-busting placeholder
+# filled in), serves that dir over HTTP, and cleans up on exit. The repo's demo/
+# stays clean.
 #
 #   ./demo/serve.sh            # serve on http://localhost:8000
 #   ./demo/serve.sh 8731       # serve on a different port
@@ -17,9 +18,11 @@ ROOT="$(cd "$DEMO_DIR/.." && pwd)"
 
 CLI_WASM="$ROOT/npm/geolibre-cli.wasm"
 TOOLS_MJS="$ROOT/npm/tools.mjs"
+LIB_JS="$ROOT/npm/geolibre_wasm.js"
+LIB_WASM="$ROOT/npm/geolibre_wasm_bg.wasm"
 SAMPLE="$ROOT/examples/sample.tif"
 
-for f in "$CLI_WASM" "$TOOLS_MJS" "$SAMPLE"; do
+for f in "$CLI_WASM" "$TOOLS_MJS" "$LIB_JS" "$LIB_WASM" "$SAMPLE"; do
   if [ ! -f "$f" ]; then
     echo "Missing $f" >&2
     echo "Run ./build.sh first to produce the npm/ WASM artifacts." >&2
@@ -31,7 +34,7 @@ STAGE="$(mktemp -d)"
 trap 'rm -rf "$STAGE"' EXIT
 
 sed 's/__BUILD__/dev/g' "$DEMO_DIR/index.html" > "$STAGE/index.html"
-cp "$TOOLS_MJS" "$CLI_WASM" "$SAMPLE" "$STAGE/"
+cp "$TOOLS_MJS" "$CLI_WASM" "$LIB_JS" "$LIB_WASM" "$SAMPLE" "$STAGE/"
 
 echo "Serving demo at http://localhost:$PORT/  (Ctrl-C to stop)"
 cd "$STAGE"

--- a/npm/README.md
+++ b/npm/README.md
@@ -65,9 +65,53 @@ const { exitCode, stdout, files } = await runTool("slope", {
 const slopeCog = files["slope.tif"]; // Uint8Array (Cloud Optimized GeoTIFF)
 ```
 
+COG subsets can be extracted from a local file or an HTTP source. HTTP sources
+use byte-range requests and do not download the full object:
+
+```js
+const { files } = await runTool("extract_cog_subset", {
+  args: [
+    "--url=https://example.com/scene.cog.tif",
+    "--bbox=-122.55,37.70,-122.35,37.84",
+    "--bbox_crs=4326",
+    "--output_crs=3857",
+    "--resolution=10",
+    "--nodata=-9999",
+    "--output=/work/subset.tif",
+  ],
+});
+const subsetCog = files["subset.tif"];
+```
+
+For a local COG, upload/provide bytes through `input` and point `--input` at
+the `/work` path:
+
+```js
+const { files } = await runTool("extract_cog_subset", {
+  args: [
+    "--input=/work/local.cog.tif",
+    "--bbox=-122.55,37.70,-122.35,37.84",
+    "--bbox_crs=4326",
+    "--output=/work/subset.tif",
+  ],
+  input: { "local.cog.tif": localCogBytes },
+});
+```
+
 Inputs are placed under `/work` (keyed by filename); any file a tool writes is
 returned in `files`. Raster outputs are Cloud Optimized GeoTIFFs; vector outputs
 are GeoJSON.
+
+When `output_crs` is set, `resolution` is interpreted in output CRS units and
+the subset is reprojected with nearest-neighbor resampling. Without
+`output_crs`, the output usually stays on the source COG grid. Sources with
+user-defined projection strings that cannot be written as EPSG metadata, such as
+the NLCD sample, default to `bbox_crs` output so GIS viewers can place the
+result. Outputs are Deflate-compressed by default. `nodata` overrides the output
+nodata metadata and is used to fill pixels introduced during reprojection.
+The subset writer preserves the source sample type for supported COG types
+(`uint8`, `float32`, and `float64`); palette-indexed `uint8` rasters retain
+their source ColorMap.
 
 ## API
 
@@ -77,6 +121,7 @@ are GeoJSON.
 | `listTools(): Promise<string[]>` | Every available tool id. |
 | `listManifests(): Promise<ToolManifest[]>` | All tool manifests (parameter schemas), for building UIs offline. |
 | `runTool(tool, { args?, input? }): Promise<ToolResult>` | Run one tool over the in-memory filesystem. |
+| `extractCogSubset(source, opts): Promise<Uint8Array>` | Extract a local or HTTP COG subset directly. |
 
 `ToolResult` is `{ exitCode: number, stdout: string[], files: Record<string, Uint8Array> }`.
 

--- a/npm/tools.d.ts
+++ b/npm/tools.d.ts
@@ -19,6 +19,27 @@ export interface RunToolOptions {
   input?: Record<string, Uint8Array | ArrayBuffer | string>;
 }
 
+export interface ExtractCogSubsetOptions {
+  /** Bounding box as [minX, minY, maxX, maxY]. */
+  bbox: [number, number, number, number];
+  /** EPSG code of bbox coordinates. */
+  bboxCrs: number;
+  /** COG overview level to read. Level 0 is full resolution. */
+  level?: number;
+  /** Target output pixel size in outputCrs units when outputCrs is set; otherwise bboxCrs units. */
+  resolution?: number;
+  /** Optional output EPSG code. User-defined source CRSs default to bboxCrs output when omitted. */
+  outputCrs?: number;
+  /** Optional output nodata value. Used as reprojection fill and output nodata metadata. */
+  nodata?: number;
+  /** Extra fetch options used for header and tile range requests. */
+  fetchOptions?: RequestInit;
+  /** Initial COG header prefix size in bytes. Default 262144. */
+  initialHeaderBytes?: number;
+  /** Maximum COG header prefix size in bytes. Default 8388608. */
+  maxHeaderBytes?: number;
+}
+
 /** A single parameter in a tool manifest. */
 export interface ToolParam {
   name: string;
@@ -46,3 +67,9 @@ export function listManifests(): Promise<ToolManifest[]>;
 
 /** Run one tool over an in-memory filesystem. */
 export function runTool(tool: string, opts?: RunToolOptions): Promise<ToolResult>;
+
+/** Extract a bbox subset from a local COG or HTTP COG. HTTP sources use byte-range requests. */
+export function extractCogSubset(
+  source: string | Uint8Array | ArrayBuffer,
+  opts: ExtractCogSubsetOptions,
+): Promise<Uint8Array>;

--- a/npm/tools.mjs
+++ b/npm/tools.mjs
@@ -11,8 +11,30 @@
 //   });
 //   const slopeCog = files["slope.tif"];  // Uint8Array
 import { WASI, File, OpenFile, ConsoleStdout, PreopenDirectory } from "@bjorn3/browser_wasi_shim";
+import initGeoLibre, { CogBuilder, CogStream, transform_bbox_epsg } from "./geolibre_wasm.js";
 
 let _module = null;
+let _libraryReady = null;
+const COG_SUBSET_TOOL_ID = "extract_cog_subset";
+const COG_SUBSET_MANIFEST = {
+  id: COG_SUBSET_TOOL_ID,
+  display_name: "Extract COG Subset",
+  summary: "Extract a bbox subset from a local or HTTP Cloud Optimized GeoTIFF.",
+  category: "Raster",
+  license_tier: "Open",
+  source: "geolibre",
+  params: [
+    { name: "input", description: "Local COG file. Provide either input or url.", required: false, schema: { kind: "input", data_kind: "raster", sample_default: false } },
+    { name: "url", description: "HTTP(S) COG URL. Provide either url or input; HTTP sources use byte-range requests.", required: false, schema: { type: "string" } },
+    { name: "bbox", description: "Bounding box as minX,minY,maxX,maxY in bbox_crs.", required: true, schema: { type: "string" } },
+    { name: "bbox_crs", description: "EPSG code of bbox coordinates.", required: true, schema: { kind: "scalar", scalar: "integer" } },
+    { name: "output", description: "Output COG path.", required: false, schema: { type: "string" } },
+    { name: "level", description: "COG overview level to read; 0 is full resolution.", required: false, schema: { kind: "scalar", scalar: "integer" } },
+    { name: "resolution", description: "Target output pixel size. Uses output_crs units when output_crs is set; otherwise bbox_crs units. Selects the closest COG overview when level is omitted.", required: false, schema: { kind: "scalar", scalar: "float" } },
+    { name: "output_crs", description: "Optional output EPSG code. When set, the subset is reprojected to this CRS. For source CRSs that cannot be written as EPSG metadata, defaults to bbox_crs.", required: false, schema: { kind: "scalar", scalar: "integer" } },
+    { name: "nodata", description: "Optional output nodata value. Used as reprojection fill and written as output nodata metadata.", required: false, schema: { kind: "scalar", scalar: "float" } },
+  ],
+};
 
 /**
  * Compile the WASI tool runner once. In browsers/bundlers it loads the bundled
@@ -32,6 +54,11 @@ export async function initTools(source) {
     _module = await WebAssembly.compileStreaming(fetch(source));
   }
   return _module;
+}
+
+async function initLibrary() {
+  if (!_libraryReady) _libraryReady = initGeoLibre();
+  return _libraryReady;
 }
 
 // Resolve one input value to bytes: a Uint8Array/ArrayBuffer as-is, or an
@@ -91,7 +118,9 @@ async function exec(argv, inputFiles) {
  */
 export async function listTools() {
   const { stdout } = await exec(["list"], {});
-  return stdout.map((s) => s.trim()).filter(Boolean);
+  const tools = stdout.map((s) => s.trim()).filter(Boolean);
+  if (!tools.includes(COG_SUBSET_TOOL_ID)) tools.push(COG_SUBSET_TOOL_ID);
+  return tools;
 }
 
 /**
@@ -101,7 +130,11 @@ export async function listTools() {
  */
 export async function listManifests() {
   const { stdout } = await exec(["manifests"], {});
-  return JSON.parse(stdout.join(""));
+  const manifests = JSON.parse(stdout.join(""));
+  if (!manifests.some((m) => m.id === COG_SUBSET_TOOL_ID)) {
+    manifests.push(COG_SUBSET_MANIFEST);
+  }
+  return manifests;
 }
 
 /**
@@ -115,5 +148,555 @@ export async function listManifests() {
  */
 export async function runTool(tool, opts = {}) {
   const { args = [], input = {} } = opts;
+  if (tool === COG_SUBSET_TOOL_ID) return runCogSubsetTool(args, input);
   return exec([tool, ...args], input);
+}
+
+function parseFlagArgs(args) {
+  const out = {};
+  for (let i = 0; i < args.length; i++) {
+    const token = args[i];
+    if (!token.startsWith("--")) continue;
+    const stripped = token.slice(2);
+    if (stripped.includes("=")) {
+      const [key, ...rest] = stripped.split("=");
+      out[key] = rest.join("=");
+    } else if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
+      out[stripped] = args[++i];
+    } else {
+      out[stripped] = true;
+    }
+  }
+  return out;
+}
+
+function parseBbox(raw) {
+  const bbox = String(raw || "").split(",").map((v) => Number(v.trim()));
+  if (bbox.length !== 4 || bbox.some((v) => !Number.isFinite(v)) || bbox[0] >= bbox[2] || bbox[1] >= bbox[3]) {
+    throw new Error("--bbox must be ordered as minX,minY,maxX,maxY");
+  }
+  return bbox;
+}
+
+function parseOptionalNumber(raw, name) {
+  if (raw == null || raw === true || String(raw).trim() === "") return undefined;
+  const value = Number(raw);
+  if (!Number.isFinite(value)) throw new Error(`--${name} must be a number`);
+  return value;
+}
+
+function parseOptionalEpsg(raw, name) {
+  if (raw == null || raw === true || String(raw).trim() === "") return undefined;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) throw new Error(`--${name} must be a positive EPSG code`);
+  return value;
+}
+
+function outputKey(path) {
+  if (!path || path === true) return "subset.tif";
+  const normalized = String(path).replace(/^\/work\/?/, "");
+  return normalized || "subset.tif";
+}
+
+async function runCogSubsetTool(args, inputFiles) {
+  const flags = parseFlagArgs(args);
+  const url = flags.url;
+  const inputPath = flags.input;
+  const bbox = parseBbox(flags.bbox);
+  const bboxCrs = Number(flags.bbox_crs ?? flags.bboxCrs ?? flags.crs);
+  const level = parseOptionalNumber(flags.level, "level");
+  const resolution = parseOptionalNumber(flags.resolution, "resolution");
+  const outputCrs = parseOptionalEpsg(flags.output_crs ?? flags.outputCrs, "output_crs");
+  const nodata = parseOptionalNumber(flags.nodata, "nodata");
+  const key = outputKey(flags.output);
+  const stdout = [];
+
+  try {
+    const source = await resolveCogSubsetSource({ url, inputPath, inputFiles });
+    const bytes = await extractCogSubset(source, { bbox, bboxCrs, level, resolution, outputCrs, nodata });
+    stdout.push(JSON.stringify({ output: `/work/${key}`, bytes: bytes.byteLength }));
+    return { exitCode: 0, stdout, files: { [key]: bytes } };
+  } catch (error) {
+    stdout.push(String(error?.message || error));
+    return { exitCode: 1, stdout, files: {} };
+  }
+}
+
+async function resolveCogSubsetSource({ url, inputPath, inputFiles }) {
+  if ((url == null || url === true || String(url).trim() === "") && !inputPath) {
+    throw new Error("provide either --url=<http COG> or --input=/work/local.tif");
+  }
+  if (url && url !== true && inputPath) {
+    throw new Error("provide only one source: --url or --input");
+  }
+  if (url && url !== true) return String(url).trim();
+
+  const key = outputKey(inputPath);
+  if (!inputFiles || !(key in inputFiles)) {
+    throw new Error(`input file not found in /work: ${inputPath}`);
+  }
+  return materializeInput(inputFiles[key]);
+}
+
+async function fetchRange(url, offset, length, fetchOptions) {
+  const end = offset + length - 1;
+  const headers = new Headers(fetchOptions?.headers || {});
+  headers.set("Range", `bytes=${offset}-${end}`);
+  try {
+    if (!headers.has("User-Agent")) headers.set("User-Agent", "Mozilla/5.0 (geolibre-wasm)");
+  } catch {
+    // Browsers treat User-Agent as a forbidden header; Node accepts it.
+  }
+
+  const resp = await fetch(url, { ...fetchOptions, headers });
+  if (resp.status !== 206) {
+    throw new Error(`server must support HTTP range requests (expected 206, got ${resp.status})`);
+  }
+  return new Uint8Array(await resp.arrayBuffer());
+}
+
+function makeSourceReader(source, fetchOptions) {
+  if (typeof source === "string") {
+    if (!/^https?:\/\//i.test(source)) throw new Error(`url must be HTTP(S), got: ${source}`);
+    return {
+      type: "http",
+      async range(offset, length) {
+        return fetchRange(source, offset, length, fetchOptions);
+      },
+    };
+  }
+
+  const bytes = new Uint8Array(source);
+  return {
+    type: "local",
+    async range(offset, length) {
+      if (offset < 0 || length < 0 || offset >= bytes.byteLength) {
+        throw new Error(`requested byte range ${offset}-${offset + length - 1} exceeds local COG size`);
+      }
+      return bytes.slice(offset, Math.min(bytes.byteLength, offset + length));
+    },
+  };
+}
+
+async function openCogStream(reader, options) {
+  const maxHeaderBytes = options.maxHeaderBytes ?? 8 * 1024 * 1024;
+  let headerBytes = options.initialHeaderBytes ?? 256 * 1024;
+  let lastError = null;
+
+  while (headerBytes <= maxHeaderBytes) {
+    const prefix = await reader.range(0, headerBytes);
+    try {
+      return { stream: new CogStream(prefix), headerBytes, header: prefix };
+    } catch (error) {
+      lastError = error;
+      const message = String(error?.message || error);
+      if (!/(need more header bytes|failed to fill whole buffer)/i.test(message)) throw error;
+      headerBytes *= 2;
+    }
+  }
+
+  throw new Error(`could not parse COG header within ${maxHeaderBytes} bytes: ${lastError}`);
+}
+
+function parseLevels(stream) {
+  return JSON.parse(stream.levels_json());
+}
+
+function tiffAccess(bytes) {
+  if (bytes[0] !== 0x49 || bytes[1] !== 0x49) throw new Error("only little-endian TIFF metadata is supported");
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const magic = dv.getUint16(2, true);
+  const big = magic === 43;
+  if (!big && magic !== 42) throw new Error("not a TIFF header");
+  return {
+    dv,
+    big,
+    inlineBytes: big ? 8 : 4,
+    firstIfdOffset: Number(big ? dv.getBigUint64(8, true) : dv.getUint32(4, true)),
+    readOffset(pos) { return Number(big ? dv.getBigUint64(pos, true) : dv.getUint32(pos, true)); },
+    readCount(pos) { return Number(big ? dv.getBigUint64(pos, true) : dv.getUint16(pos, true)); },
+    writeFirstIfd(out, offset) {
+      if (big) new DataView(out.buffer).setBigUint64(8, BigInt(offset), true);
+      else new DataView(out.buffer).setUint32(4, offset, true);
+    },
+  };
+}
+
+const TIFF_TYPE_BYTES = { 1: 1, 2: 1, 3: 2, 4: 4, 5: 8, 12: 8, 16: 8 };
+
+function readTiffIfd(bytes, offset, big) {
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const count = Number(big ? dv.getBigUint64(offset, true) : dv.getUint16(offset, true));
+  const countBytes = big ? 8 : 2;
+  const entryBytes = big ? 20 : 12;
+  const inlineBytes = big ? 8 : 4;
+  const entries = [];
+  for (let i = 0; i < count; i++) {
+    const pos = offset + countBytes + i * entryBytes;
+    const tag = dv.getUint16(pos, true);
+    const type = dv.getUint16(pos + 2, true);
+    const valueCount = Number(big ? dv.getBigUint64(pos + 4, true) : dv.getUint32(pos + 4, true));
+    const bytesLen = valueCount * (TIFF_TYPE_BYTES[type] || 1);
+    const valuePos = pos + (big ? 12 : 8);
+    const valueOffset = bytesLen <= inlineBytes
+      ? valuePos
+      : Number(big ? dv.getBigUint64(valuePos, true) : dv.getUint32(valuePos, true));
+    entries.push({ tag, type, count: valueCount, bytesLen, valuePos, valueOffset });
+  }
+  const nextOffsetPos = offset + countBytes + count * entryBytes;
+  const nextOffset = Number(big ? dv.getBigUint64(nextOffsetPos, true) : dv.getUint32(nextOffsetPos, true));
+  return { count, entries, nextOffset };
+}
+
+function readShortTag(bytes, ifd, tag) {
+  const entry = ifd.entries.find((e) => e.tag === tag);
+  if (!entry || entry.type !== 3 || entry.count < 1) return undefined;
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint16(entry.valueOffset, true);
+}
+
+function readTagBytes(bytes, ifd, tag) {
+  const entry = ifd.entries.find((e) => e.tag === tag);
+  if (!entry || entry.valueOffset + entry.bytesLen > bytes.byteLength) return undefined;
+  return { type: entry.type, count: entry.count, bytes: bytes.slice(entry.valueOffset, entry.valueOffset + entry.bytesLen) };
+}
+
+function parseTiffPalette(headerBytes) {
+  try {
+    const tiff = tiffAccess(headerBytes);
+    const ifd = readTiffIfd(headerBytes, tiff.firstIfdOffset, tiff.big);
+    if (readShortTag(headerBytes, ifd, 262) !== 3) return null;
+    const colorMap = readTagBytes(headerBytes, ifd, 320);
+    if (!colorMap || colorMap.type !== 3 || colorMap.count < 3 || colorMap.count % 3 !== 0) return null;
+    return colorMap;
+  } catch {
+    return null;
+  }
+}
+
+function writeTiffEntry(out, pos, big, tag, type, count, valueBytes, valueDataOffset) {
+  const dv = new DataView(out.buffer);
+  dv.setUint16(pos, tag, true);
+  dv.setUint16(pos + 2, type, true);
+  if (big) {
+    dv.setBigUint64(pos + 4, BigInt(count), true);
+    if (valueBytes.byteLength <= 8) out.set(valueBytes, pos + 12);
+    else dv.setBigUint64(pos + 12, BigInt(valueDataOffset), true);
+  } else {
+    dv.setUint32(pos + 4, count, true);
+    if (valueBytes.byteLength <= 4) out.set(valueBytes, pos + 8);
+    else dv.setUint32(pos + 8, valueDataOffset, true);
+  }
+}
+
+function patchTiffPalette(bytes, palette) {
+  if (!palette) return bytes;
+  const tiff = tiffAccess(bytes);
+  const oldIfd = readTiffIfd(bytes, tiff.firstIfdOffset, tiff.big);
+  const entries = oldIfd.entries.filter((e) => e.tag !== 320).sort((a, b) => a.tag - b.tag);
+  const photo = entries.find((e) => e.tag === 262);
+  if (!photo || photo.type !== 3 || photo.count !== 1) return bytes;
+
+  const insertAt = entries.findIndex((e) => e.tag > 320);
+  const paletteEntry = { tag: 320, type: palette.type, count: palette.count, bytes: palette.bytes };
+  const ordered = entries.map((e) => ({ ...e, bytes: bytes.slice(e.valueOffset, e.valueOffset + e.bytesLen) }));
+  ordered.splice(insertAt === -1 ? ordered.length : insertAt, 0, paletteEntry);
+
+  const countBytes = tiff.big ? 8 : 2;
+  const entryBytes = tiff.big ? 20 : 12;
+  const nextBytes = tiff.big ? 8 : 4;
+  const newIfdOffset = bytes.byteLength;
+  const ifdBytes = countBytes + ordered.length * entryBytes + nextBytes;
+  const extraStart = newIfdOffset + ifdBytes;
+  let extraLen = 0;
+  for (const e of ordered) {
+    const inline = e.bytes.byteLength <= tiff.inlineBytes;
+    if (!inline) extraLen += e.bytes.byteLength + (extraLen % 2);
+  }
+
+  const out = new Uint8Array(bytes.byteLength + ifdBytes + extraLen);
+  out.set(bytes, 0);
+  tiff.writeFirstIfd(out, newIfdOffset);
+  const dv = new DataView(out.buffer);
+  if (tiff.big) dv.setBigUint64(newIfdOffset, BigInt(ordered.length), true);
+  else dv.setUint16(newIfdOffset, ordered.length, true);
+
+  let extraOffset = extraStart;
+  for (let i = 0; i < ordered.length; i++) {
+    const e = ordered[i];
+    const entryPos = newIfdOffset + countBytes + i * entryBytes;
+    let valueBytes = e.bytes;
+    if (e.tag === 262) valueBytes = new Uint8Array([3, 0]);
+    let valueDataOffset = 0;
+    if (valueBytes.byteLength > tiff.inlineBytes) {
+      if ((extraOffset - extraStart) % 2) extraOffset++;
+      valueDataOffset = extraOffset;
+      out.set(valueBytes, valueDataOffset);
+      extraOffset += valueBytes.byteLength;
+    }
+    writeTiffEntry(out, entryPos, tiff.big, e.tag, e.type, e.count, valueBytes, valueDataOffset);
+  }
+
+  const nextPos = newIfdOffset + countBytes + ordered.length * entryBytes;
+  if (tiff.big) dv.setBigUint64(nextPos, BigInt(oldIfd.nextOffset), true);
+  else dv.setUint32(nextPos, oldIfd.nextOffset, true);
+  return out;
+}
+
+function selectLevelForResolution(levels, gt, datasetBbox, bbox, resolution) {
+  if (resolution == null) return 0;
+  if (!Number.isFinite(resolution) || resolution <= 0) {
+    throw new Error("resolution must be a positive number");
+  }
+
+  const datasetWidth = Math.abs(datasetBbox[2] - datasetBbox[0]);
+  const datasetHeight = Math.abs(datasetBbox[3] - datasetBbox[1]);
+  const bboxWidth = Math.abs(bbox[2] - bbox[0]);
+  const bboxHeight = Math.abs(bbox[3] - bbox[1]);
+  const scaleX = bboxWidth > 0 ? datasetWidth / bboxWidth : 1;
+  const scaleY = bboxHeight > 0 ? datasetHeight / bboxHeight : 1;
+  const targetX = resolution * scaleX;
+  const targetY = resolution * scaleY;
+
+  let best = 0;
+  let bestScore = Infinity;
+  for (let i = 0; i < levels.length; i++) {
+    const level = levels[i];
+    const levelScaleX = level.width / levels[0].width;
+    const levelScaleY = level.height / levels[0].height;
+    const px = Math.abs(gt[1] / levelScaleX);
+    const py = Math.abs(gt[5] / levelScaleY);
+    const score = Math.abs(Math.log(px / targetX)) + Math.abs(Math.log(py / targetY));
+    if (score < bestScore) {
+      best = i;
+      bestScore = score;
+    }
+  }
+  return best;
+}
+
+function outputBboxForCrs(bbox, bboxCrs, outputCrs) {
+  if (outputCrs == null || outputCrs === bboxCrs) return bbox.slice();
+  return Array.from(transform_bbox_epsg(bboxCrs, outputCrs, bbox));
+}
+
+function reprojectSubsetNearest(stream, source, src, dst, outputCrs, nodata) {
+  const fill = nodata ?? Number.NaN;
+  const out = new Float64Array(dst.width * dst.height * src.bands);
+  out.fill(fill);
+
+  const batchRows = 32;
+  for (let row0 = 0; row0 < dst.height; row0 += batchRows) {
+    const row1 = Math.min(dst.height, row0 + batchRows);
+    const coords = new Array((row1 - row0) * dst.width * 2);
+    let k = 0;
+    for (let row = row0; row < row1; row++) {
+      const y = dst.y0 + (row + 0.5) * dst.pixelHeight;
+      for (let col = 0; col < dst.width; col++) {
+        coords[k++] = dst.x0 + (col + 0.5) * dst.pixelWidth;
+        coords[k++] = y;
+      }
+    }
+
+    const srcCoords = stream.points_to_dataset_crs(outputCrs, coords);
+    k = 0;
+    for (let row = row0; row < row1; row++) {
+      for (let col = 0; col < dst.width; col++) {
+        const x = srcCoords[k++];
+        const y = srcCoords[k++];
+        if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+        const srcCol = Math.floor((x - src.x0) / src.pixelWidth);
+        const srcRow = Math.floor((y - src.y0) / src.pixelHeight);
+        if (srcCol < 0 || srcRow < 0 || srcCol >= src.width || srcRow >= src.height) continue;
+        const srcPixel = (srcRow * src.width + srcCol) * src.bands;
+        const dstPixel = ((row * dst.width) + col) * src.bands;
+        for (let band = 0; band < src.bands; band++) out[dstPixel + band] = source[srcPixel + band];
+      }
+    }
+  }
+
+  return out;
+}
+
+function windowFromBbox(gt, baseLevel, level, bbox) {
+  const [x0, pixelWidth, rowRotation, y0, colRotation, pixelHeight] = gt;
+  if (Math.abs(rowRotation) > 1e-12 || Math.abs(colRotation) > 1e-12) {
+    throw new Error("rotated/skewed COG geo-transforms are not supported");
+  }
+  if (!(pixelWidth > 0) || !(pixelHeight < 0)) {
+    throw new Error("only north-up COGs with positive pixel width and negative pixel height are supported");
+  }
+
+  const scaleX = level.width / baseLevel.width;
+  const scaleY = level.height / baseLevel.height;
+  const px = pixelWidth / scaleX;
+  const py = pixelHeight / scaleY;
+
+  const minCol = Math.floor((bbox[0] - x0) / px);
+  const maxCol = Math.ceil((bbox[2] - x0) / px);
+  const minRow = Math.floor((bbox[3] - y0) / py);
+  const maxRow = Math.ceil((bbox[1] - y0) / py);
+
+  const x = Math.max(0, Math.min(level.width, minCol));
+  const y = Math.max(0, Math.min(level.height, minRow));
+  const x2 = Math.max(0, Math.min(level.width, maxCol));
+  const y2 = Math.max(0, Math.min(level.height, maxRow));
+  if (x2 <= x || y2 <= y) throw new Error("bbox does not intersect the COG extent");
+  return { x, y, width: x2 - x, height: y2 - y, pixelWidth: px, pixelHeight: py };
+}
+
+/**
+ * Extract a bbox subset from a local or HTTP Cloud Optimized GeoTIFF. HTTP
+ * sources are read with byte-range requests, without downloading the full COG.
+ *
+ * The returned bytes are a new f64 COG containing all bands from the selected
+ * source level. `bboxCrs` is an EPSG code for `bbox`; it is reprojected to the
+ * COG CRS before selecting tiles. If `resolution` is set and `level` is omitted,
+ * the closest available COG overview level is selected. If `outputCrs` is set,
+ * the extracted source window is reprojected to that EPSG CRS with nearest
+ * neighbor resampling. Sources with user-defined projection strings default to
+ * `bboxCrs` output so the result can be written with standard EPSG metadata.
+ *
+ * @param {string|Uint8Array|ArrayBuffer} source HTTP(S) COG URL or local COG bytes.
+ * @param {object} opts
+ * @param {[number, number, number, number]} opts.bbox [minX,minY,maxX,maxY].
+ * @param {number} opts.bboxCrs EPSG code of `bbox`.
+ * @param {number} [opts.level] COG overview level to read; 0 is full res.
+ * @param {number} [opts.resolution] Target output pixel size in outputCrs units when outputCrs is set; otherwise bboxCrs units.
+ * @param {number} [opts.outputCrs] Optional output EPSG code.
+ * @param {number} [opts.nodata] Optional output nodata value.
+ * @param {RequestInit} [opts.fetchOptions] Extra fetch options for all requests.
+ * @param {number} [opts.initialHeaderBytes=262144] Initial COG header prefix size.
+ * @param {number} [opts.maxHeaderBytes=8388608] Maximum COG header prefix size.
+ * @returns {Promise<Uint8Array>}
+ */
+export async function extractCogSubset(source, opts) {
+  opts = opts || {};
+  await initLibrary();
+  const { bbox, bboxCrs, resolution, nodata } = opts || {};
+  let { level, outputCrs } = opts || {};
+  if (!Array.isArray(bbox) || bbox.length !== 4) {
+    throw new Error("opts.bbox must be [minX,minY,maxX,maxY]");
+  }
+  if (bbox.some((v) => !Number.isFinite(v)) || bbox[0] >= bbox[2] || bbox[1] >= bbox[3]) {
+    throw new Error("opts.bbox must be finite and ordered min < max");
+  }
+  if (!Number.isInteger(bboxCrs) || bboxCrs <= 0) {
+    throw new Error("opts.bboxCrs must be a positive EPSG code");
+  }
+  if (level != null && (!Number.isInteger(level) || level < 0)) {
+    throw new Error("opts.level must be a non-negative integer");
+  }
+  if (outputCrs != null && (!Number.isInteger(outputCrs) || outputCrs <= 0)) {
+    throw new Error("opts.outputCrs must be a positive EPSG code");
+  }
+  if (nodata != null && !Number.isFinite(nodata)) {
+    throw new Error("opts.nodata must be a finite number");
+  }
+
+  const reader = makeSourceReader(source, opts.fetchOptions);
+  const { stream, header } = await openCogStream(reader, opts || {});
+  const levels = parseLevels(stream);
+  const sourcePalette = parseTiffPalette(header);
+
+  if (outputCrs == null && stream.has_projection_string) outputCrs = bboxCrs;
+  const datasetBbox = Array.from(stream.bbox_to_dataset_crs(bboxCrs, bbox));
+  const requestedOutputBbox = outputBboxForCrs(bbox, bboxCrs, outputCrs);
+  const gt = Array.from(stream.geo_transform());
+  if (gt.length !== 6) throw new Error("COG has no affine geo-transform");
+  if (level == null) level = selectLevelForResolution(levels, gt, datasetBbox, requestedOutputBbox, resolution);
+  const selected = levels[level];
+  if (!selected) throw new Error(`level ${level} out of range`);
+  const win = windowFromBbox(gt, levels[0], selected, datasetBbox);
+
+  const tileSpecs = JSON.parse(stream.tiles_for_window(level, win.x, win.y, win.width, win.height));
+  const out = new Float64Array(win.width * win.height * selected.bands);
+  const tileStride = selected.tile_width * selected.tile_height * selected.bands;
+
+  for (const tile of tileSpecs) {
+    const bytes = await reader.range(tile.offset, tile.length);
+    const decoded = stream.decode_tile_f64(level, bytes);
+    if (decoded.length !== tileStride) {
+      throw new Error(`decoded tile size mismatch for tile ${tile.col},${tile.row}`);
+    }
+
+    const tileX0 = tile.col * selected.tile_width;
+    const tileY0 = tile.row * selected.tile_height;
+    const copyX0 = Math.max(win.x, tileX0);
+    const copyY0 = Math.max(win.y, tileY0);
+    const copyX1 = Math.min(win.x + win.width, tileX0 + selected.tile_width, selected.width);
+    const copyY1 = Math.min(win.y + win.height, tileY0 + selected.tile_height, selected.height);
+
+    for (let row = copyY0; row < copyY1; row++) {
+      for (let col = copyX0; col < copyX1; col++) {
+        const srcPixel = ((row - tileY0) * selected.tile_width + (col - tileX0)) * selected.bands;
+        const dstPixel = ((row - win.y) * win.width + (col - win.x)) * selected.bands;
+        for (let band = 0; band < selected.bands; band++) {
+          out[dstPixel + band] = decoded[srcPixel + band];
+        }
+      }
+    }
+  }
+
+  const subsetX0 = gt[0] + win.x * win.pixelWidth;
+  const subsetY0 = gt[3] + win.y * win.pixelHeight;
+
+  let finalData = out;
+  let finalWidth = win.width;
+  let finalHeight = win.height;
+  let finalX0 = subsetX0;
+  let finalY0 = subsetY0;
+  let finalPixelWidth = win.pixelWidth;
+  let finalPixelHeight = win.pixelHeight;
+  let finalEpsg = !stream.has_projection_string ? stream.epsg : undefined;
+  const outputNodata = nodata ?? stream.nodata;
+
+  if (outputCrs != null) {
+    const outWidth = resolution == null
+      ? win.width
+      : Math.max(1, Math.ceil((requestedOutputBbox[2] - requestedOutputBbox[0]) / resolution));
+    const outHeight = resolution == null
+      ? win.height
+      : Math.max(1, Math.ceil((requestedOutputBbox[3] - requestedOutputBbox[1]) / resolution));
+    const outPixelWidth = (requestedOutputBbox[2] - requestedOutputBbox[0]) / outWidth;
+    const outPixelHeight = -(requestedOutputBbox[3] - requestedOutputBbox[1]) / outHeight;
+
+    finalData = reprojectSubsetNearest(
+      stream,
+      out,
+      { x0: subsetX0, y0: subsetY0, pixelWidth: win.pixelWidth, pixelHeight: win.pixelHeight, width: win.width, height: win.height, bands: selected.bands },
+      { x0: requestedOutputBbox[0], y0: requestedOutputBbox[3], pixelWidth: outPixelWidth, pixelHeight: outPixelHeight, width: outWidth, height: outHeight },
+      outputCrs,
+      outputNodata,
+    );
+    finalWidth = outWidth;
+    finalHeight = outHeight;
+    finalX0 = requestedOutputBbox[0];
+    finalY0 = requestedOutputBbox[3];
+    finalPixelWidth = outPixelWidth;
+    finalPixelHeight = outPixelHeight;
+    finalEpsg = outputCrs;
+  }
+
+  const builder = new CogBuilder(finalWidth, finalHeight, selected.bands);
+  builder.set_geo_transform([finalX0, finalPixelWidth, 0, finalY0, 0, finalPixelHeight]);
+  builder.set_compression("deflate");
+  if (finalEpsg != null) builder.set_epsg(finalEpsg);
+  if (outputNodata != null) builder.set_nodata(outputNodata);
+  if (selected.sample_format === "uint" && selected.bits_per_sample === 8) {
+    const u8 = new Uint8Array(finalData.length);
+    const fill = outputNodata == null ? 0 : Math.max(0, Math.min(255, Math.round(outputNodata)));
+    for (let i = 0; i < finalData.length; i++) {
+      const v = finalData[i];
+      u8[i] = Number.isFinite(v) ? Math.max(0, Math.min(255, Math.round(v))) : fill;
+    }
+    const bytes = builder.write_u8(u8);
+    return selected.bands === 1 && sourcePalette ? patchTiffPalette(bytes, sourcePalette) : bytes;
+  }
+  if (selected.sample_format === "ieeefloat" && selected.bits_per_sample === 32) {
+    return builder.write_f32(Float32Array.from(finalData));
+  }
+  if (selected.sample_format === "ieeefloat" && selected.bits_per_sample === 64) {
+    return builder.write_f64(finalData);
+  }
+  throw new Error(`preserving source sample type is not yet supported for ${selected.sample_format}/${selected.bits_per_sample}-bit COGs`);
 }


### PR DESCRIPTION
## Summary
- Add `extractCogSubset` API and an `extract_cog_subset` tool that read a bbox subset from a local or HTTP Cloud Optimized GeoTIFF using byte-range requests, with optional reprojection to an output CRS and nearest-neighbor resampling.
- Add Rust WASM CRS transform helpers (`transform_bbox_epsg`, `transform_points_epsg`, and CogStream dataset-CRS reprojection) plus a `has_projection_string` getter for user-defined projections.
- Let demo file inputs opt out of the bundled sample default, and stage the wasm-bindgen browser library in `demo/serve.sh`.

## Test plan
- [ ] `cargo check -p geolibre-wasm --target wasm32-unknown-unknown` passes
- [ ] `cargo test -p geolibre-cli -p geolibre-tools` passes
- [ ] `./build.sh` produces the npm WASM artifacts and `node examples/node-demo.mjs` runs
- [ ] Extract a subset from a public HTTP COG with and without `output_crs` and confirm the result opens in a GIS viewer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added COG subset extraction from local files or HTTP sources using bounding boxes, optional reprojection, resolution, overview, and nodata settings.
  - Added coordinate and bounding-box transformation utilities for EPSG coordinate systems.
  - Added COG projection detection and conversion between dataset and external coordinate systems.
- **Demo**
  - Updated the demo to respect whether sample data should be used by default.
  - Improved local demo serving by including required WASM runtime files.
- **Documentation**
  - Added API documentation and usage examples for COG subset extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->