### PR TITLE
fix(pmtiles): make pmtiles_extract input optional when url is given

### DIFF
--- a/npm/tools.mjs
+++ b/npm/tools.mjs
@@ -211,6 +211,12 @@ export async function listManifests() {
         pmtiles.params.push({ ...extra });
       }
     }
+    // The native tool requires a local `input`, but through this JS path a
+    // remote `url` is an equal alternative, so `input` is optional here (the
+    // handler enforces exactly-one-source). Matches extract_cog_subset's
+    // optional `input`; without this a host UI blocks a url-only run.
+    const input = pmtiles.params.find((p) => p.name === "input");
+    if (input) input.required = false;
   }
   return manifests;
 }


### PR DESCRIPTION
Follow-up to #38. The native `pmtiles_extract` tool marks `input` required, so a host UI (GeoLibre's Processing dialog) blocked a url-only run with "Missing required parameter: input". Since the JS interception treats a remote `url` as an equal alternative to a local `input`, the augmented manifest now sets `input.required = false` (matching `extract_cog_subset`).

Verified in the GeoLibre Processing dialog against the live 136 GB Protomaps planet build: a url-only extraction (bbox + zooms, no local file) now succeeds and returns the archive bytes.