### PR TITLE
feat(pmtiles): vector_to_pmtiles — MVT tilesets from any vector layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,7 +99,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -196,7 +202,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -308,6 +314,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "brotli"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor 2.5.1",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,7 +344,17 @@ checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor",
+ "brotli-decompressor 5.0.3",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -504,6 +543,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "deku"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d631ba36587888e2f176cda075d73971c504283efd7d0112997a3fd02372c0"
+dependencies = [
+ "bitvec",
+ "deku_derive",
+]
+
+[[package]]
+name = "deku_derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9009099da9734d3dc49ce9c8c7f9b12905612c84c6dd4b4c075455743e47840d"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,7 +614,26 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "duplicate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de78e66ac9061e030587b2a2e75cc88f22304913c907b11307bca737141230cb"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+]
+
+[[package]]
+name = "earcut"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88459a2a8e3a514b6e6de38cf3aaa9250a894cb098f74a932db77fcc8341b6d0"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -543,7 +659,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -679,10 +795,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37007738a80ea34f969af54a3390dd72cacdef654974cfd449c9f6f72dbaac10"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -692,6 +820,28 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "freestiler-core"
+version = "0.1.0"
+source = "git+https://github.com/giswqs/freestiler?branch=fix%2Fgeo-0.33-wasm-compat#b77f7f0d76e11bf105e913ab6d553eb2a4a7ca00"
+dependencies = [
+ "flate2",
+ "geo",
+ "geo-types",
+ "integer-encoding 4.1.0",
+ "pmtiles2",
+ "prost",
+ "rayon",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -739,6 +889,7 @@ version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30eb1fdc57c1e5cfd11826fe0caec4b9dc7901f3758263bb506228d88c8d9e9a"
 dependencies = [
+ "earcut",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
@@ -750,6 +901,7 @@ dependencies = [
  "robust",
  "rstar",
  "sif-itree",
+ "spade",
 ]
 
 [[package]]
@@ -766,8 +918,10 @@ checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
 dependencies = [
  "approx",
  "num-traits",
+ "rayon",
  "rstar",
  "serde",
+ "spade",
 ]
 
 [[package]]
@@ -801,6 +955,7 @@ name = "geolibre-tools"
 version = "0.4.3"
 dependencies = [
  "flate2",
+ "freestiler-core",
  "geo",
  "geolibre-pmtiles",
  "h3o",
@@ -1035,7 +1190,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1056,6 +1222,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -1065,6 +1237,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hilbert_2d"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "705f81e042b11734af35c701c7f6b65f8a968a430621fa2c95e72e27f9f8be5c"
 
 [[package]]
 name = "i_float"
@@ -1080,6 +1258,9 @@ name = "i_key_sort"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d73d122b937fca067feb0ad74f62388920272b27c356d4df2d0cfdd59e044cf0"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "i_overlay"
@@ -1091,6 +1272,7 @@ dependencies = [
  "i_key_sort",
  "i_shape",
  "i_tree",
+ "rayon",
 ]
 
 [[package]]
@@ -1221,6 +1403,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1488,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "integer-encoding"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c00403deb17c3221a1fe4fb571b9ed0370b3dcd116553c77fa294a3d918699"
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,7 +1501,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1454,7 +1648,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e35d032bcec660647828527ff42c6f5776d2fd44b8357f9f6d9ac6dc07218e46"
 dependencies = [
- "brotli-decompressor",
+ "brotli-decompressor 5.0.3",
  "jxl-bitstream",
  "jxl-frame",
  "jxl-grid",
@@ -1486,7 +1680,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d36c662923f47586880211f3bc7c0d83fb3a9b410d278c7bde93450748abeef3"
 dependencies = [
- "brotli-decompressor",
+ "brotli-decompressor 5.0.3",
  "jxl-bitstream",
  "jxl-color",
  "jxl-frame",
@@ -1740,7 +1934,7 @@ checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1843,7 +2037,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1971,7 +2165,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "base64",
- "brotli",
+ "brotli 8.0.4",
  "bytes",
  "chrono",
  "flate2",
@@ -1987,7 +2181,7 @@ dependencies = [
  "snap",
  "thrift",
  "twox-hash",
- "zstd",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -2019,6 +2213,23 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "pmtiles2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df68cae0754066c0ba89fd4ca1307f496623ed49edabed4b3cafad335448cd77"
+dependencies = [
+ "ahash",
+ "brotli 3.5.0",
+ "deku",
+ "duplicate",
+ "flate2",
+ "hilbert_2d",
+ "integer-encoding 3.0.4",
+ "serde_json",
+ "zstd 0.11.2+zstd.1.5.2",
+]
 
 [[package]]
 name = "png"
@@ -2077,7 +2288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2087,6 +2298,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
 dependencies = [
  "num-integer",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -2114,7 +2359,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2189,6 +2457,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2546,7 +2820,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2655,6 +2929,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
+name = "spade"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
+dependencies = [
+ "hashbrown 0.16.1",
+ "num-traits",
+ "robust",
+ "smallvec",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2673,10 +2959,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2697,8 +3000,14 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -2737,7 +3046,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2748,7 +3057,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2758,7 +3067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
- "integer-encoding",
+ "integer-encoding 3.0.4",
  "ordered-float 2.10.1",
 ]
 
@@ -2823,6 +3132,23 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2899,7 +3225,7 @@ checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3061,7 +3387,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -3104,7 +3430,7 @@ checksum = "fccaddcb2cd722baa7453b4c3d2cb2a3071597bb91f7a4373e8775bdb151778c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3383,7 +3709,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3394,7 +3720,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3504,6 +3830,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3525,7 +3860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -3536,10 +3871,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3555,7 +3890,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3604,6 +3939,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3638,7 +3982,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3659,7 +4003,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3679,7 +4023,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3719,7 +4063,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3774,11 +4118,30 @@ dependencies = [
 
 [[package]]
 name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 7.2.4",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
 [[package]]
 name = "freestiler-core"
 version = "0.1.0"
-source = "git+https://github.com/giswqs/freestiler?branch=fix%2Fgeo-0.33-wasm-compat#b77f7f0d76e11bf105e913ab6d553eb2a4a7ca00"
+source = "git+https://github.com/giswqs/freestiler?rev=b77f7f0d76e11bf105e913ab6d553eb2a4a7ca00#b77f7f0d76e11bf105e913ab6d553eb2a4a7ca00"
 dependencies = [
  "flate2",
  "geo",

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ rendering tools that the whitebox suite lacks (all pure-Rust, running in WASM):
 | `render_raster_png` | Render a raster band to a PNG through a colormap (viridis/magma/turbo/terrain/grayscale); no-data becomes transparent. |
 | `raster_to_tiles` | Slice a raster into a Web Mercator (EPSG:3857) XYZ PNG tile pyramid for web maps. |
 | `write_pmtiles` | Render a raster into a single PMTiles archive (the Web Mercator PNG pyramid as one file). |
+| `vector_to_pmtiles` | Pack a vector layer (GeoJSON, Shapefile, GeoPackage, FlatGeobuf, GeoParquet, ...) into a single PMTiles archive of Mapbox Vector Tiles, ready to style in MapLibre. Clipping, per-zoom simplification and MVT encoding come from [freestiler](https://walker-data.com/freestiler/). |
 | `pmtiles_extract` | Extract a bbox/zoom subset of a PMTiles archive into a new self-contained archive (e.g. an offline basemap from a Protomaps planet build). The browser library exposes the same engine as `PmtilesExtractor`, driven by host `fetch` range requests. |
 | `spectral_index` | Compute a spectral index (NDVI, NDWI, NDBI, NBR, EVI, SAVI) from a multi-band raster. |
 | `write_geoparquet` | Convert any supported vector format to GeoParquet, Hilbert-sorted with a bbox covering column and ZSTD compression by default. |

--- a/crates/geolibre-pmtiles/src/writer.rs
+++ b/crates/geolibre-pmtiles/src/writer.rs
@@ -2,18 +2,18 @@
 //!
 //! [`assemble`] is the general path: caller-provided directory entries over an
 //! already-laid-out tile-data section (what [`crate::extract`] produces).
-//! [`build_png`] is the historical convenience used by GeoLibre's tiling tools:
-//! pack loose PNG tiles into a fresh archive.
+//! [`build_png`] and [`build_mvt`] are the conveniences used by GeoLibre's
+//! tiling tools: pack loose raster or vector tiles into a fresh archive.
 
 use std::collections::HashMap;
 
 use crate::format::{
     compress, serialize_directory, Entry, Header, COMPRESSION_GZIP, COMPRESSION_NONE,
-    HEADER_LEN, PRELUDE_LEN, TILETYPE_PNG,
+    HEADER_LEN, PRELUDE_LEN, TILETYPE_MVT, TILETYPE_PNG,
 };
 use crate::{LonLatBounds, PmtilesError};
 
-/// One tile to include in a [`build_png`] archive.
+/// One tile to include in a [`build_png`] or [`build_mvt`] archive.
 pub struct Tile {
     pub z: u8,
     pub x: u32,
@@ -185,6 +185,63 @@ pub fn build_png(
         num_tile_contents: seen.len() as u64,
     };
     assemble(&entries, &tile_data, br#"{"type":"overlay","format":"png"}"#, &params)
+}
+
+/// Builds a complete archive from loose MVT tiles. `tiles` carry *uncompressed*
+/// protobuf; each blob is gzipped here to match the `GZIP` tile compression
+/// recorded in the header, which is what MVT readers expect (unlike PNG, which
+/// is already compressed and so ships as `NONE`). `tiles` need not be sorted;
+/// identical blobs are deduplicated after compression.
+///
+/// `metadata` is uncompressed TileJSON, supplied by the caller rather than
+/// built here so this crate stays free of a JSON dependency. It must carry a
+/// `vector_layers` array, without which MapLibre cannot style the source.
+pub fn build_mvt(
+    mut tiles: Vec<Tile>,
+    bounds: &LonLatBounds,
+    min_zoom: u8,
+    max_zoom: u8,
+    metadata: &[u8],
+) -> Result<Vec<u8>, PmtilesError> {
+    tiles.sort_by_key(|t| crate::tilemath::zxy_to_tile_id(t.z, t.x, t.y));
+
+    let addressed = tiles.len() as u64;
+    let mut tile_data: Vec<u8> = Vec::new();
+    let mut seen: HashMap<Vec<u8>, (u64, u32)> = HashMap::new();
+    let mut entries: Vec<Entry> = Vec::with_capacity(tiles.len());
+    for t in &tiles {
+        let blob = compress(&t.data, COMPRESSION_GZIP)?;
+        let (offset, length) = match seen.get(&blob) {
+            Some(&(off, len)) => (off, len),
+            None => {
+                let off = tile_data.len() as u64;
+                let len = blob.len() as u32;
+                tile_data.extend_from_slice(&blob);
+                seen.insert(blob, (off, len));
+                (off, len)
+            }
+        };
+        entries.push(Entry {
+            tile_id: crate::tilemath::zxy_to_tile_id(t.z, t.x, t.y),
+            offset,
+            length,
+            run_length: 1,
+        });
+    }
+
+    let params = ArchiveParams {
+        tile_type: TILETYPE_MVT,
+        tile_compression: COMPRESSION_GZIP,
+        min_zoom,
+        max_zoom,
+        bounds: *bounds,
+        center_zoom: min_zoom,
+        center_lon: (bounds.min_lon + bounds.max_lon) / 2.0,
+        center_lat: (bounds.min_lat + bounds.max_lat) / 2.0,
+        num_addressed_tiles: addressed,
+        num_tile_contents: seen.len() as u64,
+    };
+    assemble(&entries, &tile_data, metadata, &params)
 }
 
 #[cfg(test)]

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -23,6 +23,14 @@ parquet = "58.3"
 # geolibre-wasm directly, which is why it is its own lightweight crate.
 geolibre-pmtiles = { path = "../geolibre-pmtiles" }
 
+# Vector tiling engine (clip, simplify, quantize, MVT encode) behind
+# vector_to_pmtiles. Points at a fork because upstream pins rayon `=1.10.0` and
+# geo 0.29, neither of which can resolve alongside wbraster or our geo 0.33; the
+# fork drops those pins. Upstream keeps them for CRAN's Rust 1.77.2 checks, so
+# the change is not upstreamable. Default features only: `duckdb`/`geoparquet`
+# would pull bundled C++ and arrow, which do not belong in the wasm build.
+freestiler-core = { git = "https://github.com/giswqs/freestiler", branch = "fix/geo-0.33-wasm-compat", default-features = false }
+
 serde_json = "1"
 # Pure-Rust PNG encoder (miniz_oxide backend), used by render_raster_png and
 # raster_to_tiles. Compiles cleanly to wasm32-wasip1.

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -27,9 +27,11 @@ geolibre-pmtiles = { path = "../geolibre-pmtiles" }
 # vector_to_pmtiles. Points at a fork because upstream pins rayon `=1.10.0` and
 # geo 0.29, neither of which can resolve alongside wbraster or our geo 0.33; the
 # fork drops those pins. Upstream keeps them for CRAN's Rust 1.77.2 checks, so
-# the change is not upstreamable. Default features only: `duckdb`/`geoparquet`
-# would pull bundled C++ and arrow, which do not belong in the wasm build.
-freestiler-core = { git = "https://github.com/giswqs/freestiler", branch = "fix/geo-0.33-wasm-compat", default-features = false }
+# the change is not upstreamable. Pinned to a rev rather than the fork's
+# `fix/geo-0.33-wasm-compat` branch so the tiler cannot drift under us. Default
+# features only: `duckdb`/`geoparquet` would pull bundled C++ and arrow, which
+# do not belong in the wasm build.
+freestiler-core = { git = "https://github.com/giswqs/freestiler", rev = "b77f7f0d76e11bf105e913ab6d553eb2a4a7ca00", default-features = false }
 
 serde_json = "1"
 # Pure-Rust PNG encoder (miniz_oxide backend), used by render_raster_png and

--- a/crates/geolibre-tools/src/lib.rs
+++ b/crates/geolibre-tools/src/lib.rs
@@ -32,6 +32,7 @@ mod spectral_index;
 mod vector_common;
 mod vector_convert;
 mod vector_to_h3;
+mod vector_to_pmtiles;
 mod write_pmtiles;
 
 use std::collections::BTreeMap;
@@ -70,6 +71,7 @@ pub fn geolibre_tools() -> Vec<Box<dyn Tool>> {
         Box::new(raster_to_h3::RasterToH3Tool),
         Box::new(render_vector_png::RenderVectorPngTool),
         Box::new(write_pmtiles::WritePmTilesTool),
+        Box::new(vector_to_pmtiles::VectorToPmTilesTool),
         Box::new(pmtiles_extract::PmtilesExtractTool),
     ]
 }
@@ -184,6 +186,15 @@ pub fn geolibre_param_schemas(tool_id: &str) -> Option<BTreeMap<String, ToolPara
             ("method", ToolParamSchema::enum_values(&["bilinear", "nearest", "cubic"])),
             ("min", float()),
             ("max", float()),
+        ]),
+        "vector_to_pmtiles" => schemas(&[
+            ("input", vector_in()),
+            ("output", file_out()),
+            ("min_zoom", int()),
+            ("max_zoom", int()),
+            ("layer_name", ToolParamSchema::string()),
+            ("simplify", ToolParamSchema::bool()),
+            ("drop_rate", float()),
         ]),
         "pmtiles_extract" => schemas(&[
             ("input", ToolParamSchema::input(ToolDatasetSchema::File)),

--- a/crates/geolibre-tools/src/pmtiles.rs
+++ b/crates/geolibre-tools/src/pmtiles.rs
@@ -22,3 +22,16 @@ pub fn build(
     geolibre_pmtiles::writer::build_png(tiles, bounds, min_zoom, max_zoom)
         .map_err(|e| ToolError::Execution(e.to_string()))
 }
+
+/// Builds a complete PMTiles v3 archive from uncompressed MVT tiles and
+/// TileJSON `metadata`. See [`geolibre_pmtiles::writer::build_mvt`].
+pub fn build_vector(
+    tiles: Vec<Tile>,
+    bounds: &LonLatBounds,
+    min_zoom: u8,
+    max_zoom: u8,
+    metadata: &[u8],
+) -> Result<Vec<u8>, ToolError> {
+    geolibre_pmtiles::writer::build_mvt(tiles, bounds, min_zoom, max_zoom, metadata)
+        .map_err(|e| ToolError::Execution(e.to_string()))
+}

--- a/crates/geolibre-tools/src/vector_to_pmtiles.rs
+++ b/crates/geolibre-tools/src/vector_to_pmtiles.rs
@@ -1,0 +1,512 @@
+//! GeoLibre tool: pack a vector layer into a single PMTiles archive.
+//!
+//! The vector counterpart to `write_pmtiles`: instead of a PNG raster pyramid
+//! it builds a Mapbox Vector Tile (MVT) pyramid, so a whole styleable overlay
+//! is one download. Tiling (clip, simplify, quantize, MVT encode) is delegated
+//! to `freestiler-core`; this module adapts `wbvector::Layer` to that engine's
+//! input types and hands the resulting tiles to the shared PMTiles writer.
+
+use std::collections::BTreeMap;
+
+use freestiler_core::engine::{compute_all_bounds, generate_tiles, SilentReporter, TileConfig};
+use freestiler_core::pmtiles_writer::TileFormat;
+use freestiler_core::tiler::{
+    Feature as MvtFeature, Geometry as MvtGeometry, LayerData, PropertyValue,
+};
+use geo::{Coord as GeoCoord, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
+use serde_json::{json, Value};
+use wbcore::{
+    LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata,
+    ToolParamSpec, ToolRunResult,
+};
+use wbvector::{Coord, FieldType, FieldValue, Geometry, Layer, Ring};
+
+use crate::common::write_bytes;
+use crate::pmtiles::{self, LonLatBounds, Tile};
+use crate::vector_common::{load_input_layer, parse_optional_str};
+
+/// The tiling engine works in lon/lat, so anything else is reprojected first.
+const WGS84_EPSG: u32 = 4326;
+
+/// Beyond this, tile counts explode while MVT detail is already at the 4096
+/// quantization grid's limit.
+const MAX_ZOOM: u64 = 18;
+
+/// Web Mercator's latitude limit.
+const MERCATOR_LAT_LIMIT: f64 = 85.051_128_779_806_59;
+
+/// Packs a vector layer into a single PMTiles archive of MVT tiles.
+pub struct VectorToPmTilesTool;
+
+impl Tool for VectorToPmTilesTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "vector_to_pmtiles",
+            display_name: "Vector to PMTiles",
+            summary: "Pack a vector layer into a single PMTiles archive (Mapbox Vector Tile pyramid).",
+            category: ToolCategory::Conversion,
+            license_tier: LicenseTier::Open,
+            params: vec![
+                ToolParamSpec { name: "input", description: "Input vector file path (GeoJSON, Shapefile, GeoPackage, FlatGeobuf, GeoParquet, ...).", required: true },
+                ToolParamSpec { name: "output", description: "Output PMTiles file path (e.g. /work/roads.pmtiles).", required: true },
+                ToolParamSpec { name: "min_zoom", description: "Minimum zoom level (default 0).", required: false },
+                ToolParamSpec { name: "max_zoom", description: "Maximum zoom level (default 14, maximum 18).", required: false },
+                ToolParamSpec { name: "layer_name", description: "Name of the layer inside the tiles, used when styling (default: the input layer's name).", required: false },
+                ToolParamSpec { name: "simplify", description: "Simplify geometries per zoom level (default true).", required: false },
+                ToolParamSpec { name: "drop_rate", description: "Rate at which features are dropped at low zooms, as in tippecanoe (default: no dropping).", required: false },
+            ],
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        for key in ["input", "output"] {
+            if args.get(key).and_then(Value::as_str).is_none() {
+                return Err(ToolError::Validation(format!(
+                    "missing required string parameter '{key}'"
+                )));
+            }
+        }
+        let (min_zoom, max_zoom) = zoom_range(args)?;
+        if min_zoom > max_zoom {
+            return Err(ToolError::Validation(format!(
+                "min_zoom ({min_zoom}) must not exceed max_zoom ({max_zoom})"
+            )));
+        }
+        if let Some(rate) = args.get("drop_rate") {
+            let rate = rate
+                .as_f64()
+                .ok_or_else(|| ToolError::Validation("drop_rate must be a number".to_string()))?;
+            if !(rate.is_finite() && rate > 0.0) {
+                return Err(ToolError::Validation(
+                    "drop_rate must be a finite number greater than 0".to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = require_str(args, "input")?;
+        let output = require_str(args, "output")?;
+        let (min_zoom, max_zoom) = zoom_range(args)?;
+        let simplify = args.get("simplify").and_then(Value::as_bool).unwrap_or(true);
+        let drop_rate = args.get("drop_rate").and_then(Value::as_f64);
+
+        let layer = load_input_layer(input)?;
+        if layer.features.is_empty() {
+            return Err(ToolError::Validation(
+                "input layer has no features to tile".to_string(),
+            ));
+        }
+
+        let layer = to_wgs84(layer, ctx)?;
+        let name = match parse_optional_str(args, "layer_name")? {
+            Some(n) => n.to_string(),
+            None if !layer.name.trim().is_empty() => layer.name.clone(),
+            None => "layer".to_string(),
+        };
+
+        let field_names: Vec<String> = layer
+            .schema
+            .fields()
+            .iter()
+            .map(|f| f.name.clone())
+            .collect();
+        let field_types: Vec<String> = layer
+            .schema
+            .fields()
+            .iter()
+            .map(|f| tilejson_field_type(&f.field_type).to_string())
+            .collect();
+
+        ctx.progress.info("converting geometries");
+        let features = convert_features(&layer);
+        if features.is_empty() {
+            return Err(ToolError::Execution(
+                "no tileable geometries found (all features were empty or unsupported)".to_string(),
+            ));
+        }
+        let feature_count = features.len();
+
+        let data = LayerData {
+            name: name.clone(),
+            features,
+            prop_names: field_names.clone(),
+            prop_types: field_types
+                .iter()
+                .map(|t| t.to_lowercase())
+                .collect(),
+            min_zoom: min_zoom as u8,
+            max_zoom: max_zoom as u8,
+        };
+        let layers = [data];
+
+        let (west, south, east, north) = compute_all_bounds(&layers);
+        if ![west, south, east, north].iter().all(|v| v.is_finite()) {
+            return Err(ToolError::Execution(
+                "input geometries have no finite extent".to_string(),
+            ));
+        }
+
+        let config = TileConfig {
+            tile_format: TileFormat::Mvt,
+            min_zoom: min_zoom as u8,
+            max_zoom: max_zoom as u8,
+            base_zoom: None,
+            simplification: simplify,
+            drop_rate,
+            cluster_distance: None,
+            cluster_maxzoom: None,
+            coalesce: false,
+        };
+
+        ctx.progress.info("generating vector tiles");
+        let generated = generate_tiles(&layers, &config, &SilentReporter)
+            .map_err(|e| ToolError::Execution(format!("vector tiling failed: {e}")))?;
+        if generated.is_empty() {
+            return Err(ToolError::Execution(
+                "tiling produced no tiles for the requested zoom range".to_string(),
+            ));
+        }
+        let tile_count = generated.len();
+
+        let tiles: Vec<Tile> = generated
+            .into_iter()
+            .map(|(c, data)| Tile { z: c.z, x: c.x, y: c.y, data })
+            .collect();
+        let bounds = clamp_bounds(west, south, east, north);
+
+        ctx.progress.info("packing PMTiles archive");
+        let metadata = tilejson(&name, &field_names, &field_types, &bounds, min_zoom, max_zoom);
+        let archive = pmtiles::build_vector(
+            tiles,
+            &bounds,
+            min_zoom as u8,
+            max_zoom as u8,
+            metadata.to_string().as_bytes(),
+        )?;
+        write_bytes(output, &archive)?;
+
+        let mut outputs = BTreeMap::new();
+        outputs.insert("output".to_string(), json!(output));
+        outputs.insert("layer_name".to_string(), json!(name));
+        outputs.insert("min_zoom".to_string(), json!(min_zoom));
+        outputs.insert("max_zoom".to_string(), json!(max_zoom));
+        outputs.insert("features".to_string(), json!(feature_count));
+        outputs.insert("tiles".to_string(), json!(tile_count));
+        outputs.insert("bytes".to_string(), json!(archive.len()));
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+fn require_str<'a>(args: &'a ToolArgs, key: &str) -> Result<&'a str, ToolError> {
+    args.get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| ToolError::Validation(format!("missing required string parameter '{key}'")))
+}
+
+/// Clamps a raw data extent to what a PMTiles header and TileJSON can express.
+/// Source data legitimately carries out-of-range longitudes — datasets that
+/// unwrap across the antimeridian rather than splitting at it are common, e.g.
+/// Alaska reaching past -180 — and the tiler clips such geometry at the
+/// projection edge. The tiled area therefore never exceeds these limits even
+/// when the input extent does, so reporting the raw extent would advertise
+/// coverage that no tile in the archive actually provides.
+fn clamp_bounds(west: f64, south: f64, east: f64, north: f64) -> LonLatBounds {
+    LonLatBounds {
+        min_lon: west.clamp(-180.0, 180.0),
+        min_lat: south.clamp(-MERCATOR_LAT_LIMIT, MERCATOR_LAT_LIMIT),
+        max_lon: east.clamp(-180.0, 180.0),
+        max_lat: north.clamp(-MERCATOR_LAT_LIMIT, MERCATOR_LAT_LIMIT),
+    }
+}
+
+fn zoom_range(args: &ToolArgs) -> Result<(u64, u64), ToolError> {
+    let min_zoom = args.get("min_zoom").and_then(Value::as_u64).unwrap_or(0);
+    let max_zoom = args.get("max_zoom").and_then(Value::as_u64).unwrap_or(14);
+    if max_zoom > MAX_ZOOM {
+        return Err(ToolError::Validation(format!(
+            "max_zoom must be <= {MAX_ZOOM}"
+        )));
+    }
+    Ok((min_zoom, max_zoom))
+}
+
+/// Reprojects `layer` to WGS84 unless it is already there. A layer with no
+/// declared CRS is taken at face value as lon/lat, which is what the formats
+/// that omit it (notably GeoJSON, whose spec fixes CRS84) mean by it.
+fn to_wgs84(layer: Layer, ctx: &ToolContext) -> Result<Layer, ToolError> {
+    match layer.crs.as_ref().and_then(|c| c.epsg) {
+        Some(WGS84_EPSG) => Ok(layer),
+        Some(_) => {
+            ctx.progress.info("reprojecting to EPSG:4326");
+            wbvector::reproject::layer_to_epsg(&layer, WGS84_EPSG)
+                .map_err(|e| ToolError::Execution(format!("reprojection to 4326 failed: {e}")))
+        }
+        None => {
+            ctx.progress
+                .info("input has no declared CRS; assuming EPSG:4326 (lon/lat)");
+            Ok(layer)
+        }
+    }
+}
+
+/// Flattens `layer`'s features into the tiling engine's representation.
+/// Geometry collections contribute one feature per member, each carrying a copy
+/// of the parent's attributes; empty and null geometries are dropped, since the
+/// MVT encoder has nothing to emit for them.
+fn convert_features(layer: &Layer) -> Vec<MvtFeature> {
+    let mut out = Vec::with_capacity(layer.features.len());
+    for feature in &layer.features {
+        let Some(geometry) = feature.geometry.as_ref() else {
+            continue;
+        };
+        let mut geoms = Vec::new();
+        flatten_geometry(geometry, &mut geoms);
+        let properties: Vec<PropertyValue> =
+            feature.attributes.iter().map(convert_value).collect();
+        for geom in geoms {
+            out.push(MvtFeature {
+                id: Some(feature.fid),
+                geometry: geom,
+                properties: properties.clone(),
+            });
+        }
+    }
+    out
+}
+
+fn flatten_geometry(geom: &Geometry, out: &mut Vec<MvtGeometry>) {
+    match geom {
+        Geometry::Point(c) => out.push(MvtGeometry::Point(Point::new(c.x, c.y))),
+        Geometry::MultiPoint(cs) if !cs.is_empty() => out.push(MvtGeometry::MultiPoint(
+            MultiPoint(cs.iter().map(|c| Point::new(c.x, c.y)).collect()),
+        )),
+        Geometry::LineString(cs) if cs.len() >= 2 => {
+            out.push(MvtGeometry::LineString(to_line_string(cs)))
+        }
+        Geometry::MultiLineString(lines) => {
+            let lines: Vec<LineString<f64>> = lines
+                .iter()
+                .filter(|cs| cs.len() >= 2)
+                .map(|cs| to_line_string(cs))
+                .collect();
+            if !lines.is_empty() {
+                out.push(MvtGeometry::MultiLineString(MultiLineString(lines)));
+            }
+        }
+        Geometry::Polygon {
+            exterior,
+            interiors,
+        } => {
+            if let Some(poly) = to_polygon(exterior, interiors) {
+                out.push(MvtGeometry::Polygon(poly));
+            }
+        }
+        Geometry::MultiPolygon(polys) => {
+            let polys: Vec<Polygon<f64>> = polys
+                .iter()
+                .filter_map(|(exterior, interiors)| to_polygon(exterior, interiors))
+                .collect();
+            if !polys.is_empty() {
+                out.push(MvtGeometry::MultiPolygon(MultiPolygon(polys)));
+            }
+        }
+        Geometry::GeometryCollection(members) => {
+            for member in members {
+                flatten_geometry(member, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn to_line_string(coords: &[Coord]) -> LineString<f64> {
+    LineString(
+        coords
+            .iter()
+            .map(|c| GeoCoord { x: c.x, y: c.y })
+            .collect(),
+    )
+}
+
+/// A ring needs 4 positions to bound any area (3 distinct plus the repeated
+/// closing vertex); anything shorter is degenerate and yields no polygon.
+fn to_polygon(exterior: &Ring, interiors: &[Ring]) -> Option<Polygon<f64>> {
+    if exterior.0.len() < 4 {
+        return None;
+    }
+    Some(Polygon::new(
+        to_line_string(&exterior.0),
+        interiors
+            .iter()
+            .filter(|r| r.0.len() >= 4)
+            .map(|r| to_line_string(&r.0))
+            .collect(),
+    ))
+}
+
+fn convert_value(value: &FieldValue) -> PropertyValue {
+    match value {
+        FieldValue::Integer(v) => PropertyValue::Int(*v),
+        FieldValue::Float(v) => PropertyValue::Double(*v),
+        FieldValue::Text(v) => PropertyValue::String(v.clone()),
+        FieldValue::Boolean(v) => PropertyValue::Bool(*v),
+        FieldValue::Date(v) | FieldValue::DateTime(v) => PropertyValue::String(v.clone()),
+        // MVT has no binary property type, and inlining blobs into every tile
+        // that touches the feature would bloat the archive regardless.
+        FieldValue::Blob(_) | FieldValue::Null => PropertyValue::Null,
+    }
+}
+
+/// TileJSON's `fields` vocabulary, which is narrower than the source schema's.
+fn tilejson_field_type(field_type: &FieldType) -> &'static str {
+    match field_type {
+        FieldType::Integer | FieldType::Float => "Number",
+        FieldType::Boolean => "Boolean",
+        _ => "String",
+    }
+}
+
+/// Builds the TileJSON metadata block. The `vector_layers` array is what lets a
+/// renderer discover the layer id and its fields; MapLibre will not style a
+/// vector source without it.
+fn tilejson(
+    name: &str,
+    field_names: &[String],
+    field_types: &[String],
+    bounds: &LonLatBounds,
+    min_zoom: u64,
+    max_zoom: u64,
+) -> Value {
+    let fields: serde_json::Map<String, Value> = field_names
+        .iter()
+        .zip(field_types)
+        .map(|(n, t)| (n.clone(), json!(t)))
+        .collect();
+    json!({
+        "name": name,
+        "type": "overlay",
+        "format": "pbf",
+        "minzoom": min_zoom,
+        "maxzoom": max_zoom,
+        "bounds": [bounds.min_lon, bounds.min_lat, bounds.max_lon, bounds.max_lat],
+        "vector_layers": [{
+            "id": name,
+            "fields": fields,
+            "minzoom": min_zoom,
+            "maxzoom": max_zoom,
+        }],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ring(coords: &[(f64, f64)]) -> Ring {
+        Ring(
+            coords
+                .iter()
+                .map(|(x, y)| Coord { x: *x, y: *y, z: None, m: None })
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn flattens_geometry_collections_into_members() {
+        let gc = Geometry::GeometryCollection(vec![
+            Geometry::Point(Coord { x: 1.0, y: 2.0, z: None, m: None }),
+            Geometry::GeometryCollection(vec![Geometry::Point(Coord {
+                x: 3.0,
+                y: 4.0,
+                z: None,
+                m: None,
+            })]),
+        ]);
+        let mut out = Vec::new();
+        flatten_geometry(&gc, &mut out);
+        assert_eq!(out.len(), 2, "nested collections should flatten recursively");
+    }
+
+    #[test]
+    fn drops_degenerate_geometries() {
+        let mut out = Vec::new();
+        // A single-vertex line and a 3-position ring cannot be rendered.
+        flatten_geometry(
+            &Geometry::LineString(vec![Coord { x: 0.0, y: 0.0, z: None, m: None }]),
+            &mut out,
+        );
+        flatten_geometry(
+            &Geometry::Polygon {
+                exterior: ring(&[(0.0, 0.0), (1.0, 0.0), (0.0, 0.0)]),
+                interiors: vec![],
+            },
+            &mut out,
+        );
+        assert!(out.is_empty(), "degenerate geometries should be dropped");
+    }
+
+    #[test]
+    fn keeps_polygon_but_drops_degenerate_hole() {
+        let mut out = Vec::new();
+        flatten_geometry(
+            &Geometry::Polygon {
+                exterior: ring(&[(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0), (0.0, 0.0)]),
+                interiors: vec![ring(&[(0.5, 0.5), (1.0, 0.5), (0.5, 0.5)])],
+            },
+            &mut out,
+        );
+        match out.as_slice() {
+            [MvtGeometry::Polygon(p)] => assert!(p.interiors().is_empty()),
+            _ => panic!("expected a single polygon with its degenerate hole dropped"),
+        }
+    }
+
+    #[test]
+    fn tilejson_declares_vector_layers_for_styling() {
+        let meta = tilejson(
+            "roads",
+            &["name".to_string(), "lanes".to_string()],
+            &["String".to_string(), "Number".to_string()],
+            &LonLatBounds { min_lon: -1.0, min_lat: -2.0, max_lon: 3.0, max_lat: 4.0 },
+            0,
+            14,
+        );
+        let layer = &meta["vector_layers"][0];
+        assert_eq!(layer["id"], "roads");
+        assert_eq!(layer["fields"]["lanes"], "Number");
+        assert_eq!(meta["format"], "pbf");
+    }
+
+    #[test]
+    fn bounds_are_clamped_to_the_tiled_area() {
+        // The US states dataset unwraps Alaska past the antimeridian to
+        // -188.9; the tiler clips there, so the header must not claim it.
+        let b = clamp_bounds(-188.905, 17.93, -65.627, 71.35);
+        assert_eq!(b.min_lon, -180.0);
+        assert_eq!(b.max_lon, -65.627);
+        assert_eq!(b.min_lat, 17.93);
+
+        let polar = clamp_bounds(-10.0, -89.0, 10.0, 89.0);
+        assert!(polar.min_lat > -85.06 && polar.max_lat < 85.06);
+    }
+
+    #[test]
+    fn in_range_bounds_pass_through_untouched() {
+        let b = clamp_bounds(-1.5, -2.5, 3.5, 4.5);
+        assert_eq!((b.min_lon, b.min_lat, b.max_lon, b.max_lat), (-1.5, -2.5, 3.5, 4.5));
+    }
+
+    #[test]
+    fn blobs_become_null_to_keep_attributes_aligned() {
+        let values = [
+            FieldValue::Text("a".to_string()),
+            FieldValue::Blob(vec![1, 2, 3]),
+            FieldValue::Integer(7),
+        ];
+        let converted: Vec<PropertyValue> = values.iter().map(convert_value).collect();
+        assert_eq!(converted.len(), 3, "positions must line up with prop_names");
+        assert!(matches!(converted[1], PropertyValue::Null));
+    }
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -91,8 +91,15 @@
       import { initTools, listManifests, runTool } from "./tools.mjs?v=__BUILD__";
 
       const $ = (id) => document.getElementById(id);
-      const FILE_RE = /\.(tif|tiff|geojson|json|shp|las|laz|csv|dep|txt|html|asc)$/i;
-      const RASTER_OUT = "image/tiff";
+      const FILE_RE = /\.(tif|tiff|geojson|json|shp|las|laz|csv|dep|txt|html|asc|pmtiles)$/i;
+      const MIME = {
+        tif: "image/tiff", tiff: "image/tiff", png: "image/png",
+        geojson: "application/geo+json", json: "application/json",
+        pmtiles: "application/vnd.pmtiles", csv: "text/csv",
+        txt: "text/plain", html: "text/html",
+      };
+      const mimeFor = (name) =>
+        MIME[String(name).split(".").pop().toLowerCase()] ?? "application/octet-stream";
 
       let manifests = [];
       let sampleBytes = null; // lazily-fetched bundled sample.tif
@@ -497,7 +504,7 @@
             produced.find(([n]) => outputs.includes(n)) || produced[0];
           if (pick) {
             const [name, bytes] = pick;
-            const url = URL.createObjectURL(new Blob([bytes], { type: RASTER_OUT }));
+            const url = URL.createObjectURL(new Blob([bytes], { type: mimeFor(name) }));
             dl.href = url;
             dl.download = name;
             dl.textContent = `Download ${name}`;


### PR DESCRIPTION
## What

The PMTiles writer could only pack PNG raster pyramids. This adds the vector counterpart: read any `wbvector`-supported layer (GeoJSON, Shapefile, GeoPackage, FlatGeobuf, GeoParquet, ...) and pack a Mapbox Vector Tile pyramid into one styleable `.pmtiles`.

```
geolibre vector_to_pmtiles --input=us-states.geojson --output=states.pmtiles --max_zoom=6
{"bytes":99578,"features":52,"layer_name":"states","max_zoom":6,"min_zoom":0,"tiles":183}
```

## Why a dependency instead of hand-rolling

The tiling itself — clipping, per-zoom Visvalingam-Whyatt simplification, 4096-grid quantization, MVT protobuf encoding, tippecanoe-style feature dropping — comes from [`freestiler-core`](https://walker-data.com/freestiler/) (MIT, Kyle Walker) rather than being reimplemented. That's ~7k lines of well-trodden tiler we don't own, including the long tail that's easy to get wrong.

It points at a **fork**, pinned to a rev. Upstream pins `rayon = "=1.10.0"` and `geo 0.29` to hold its tree at Rust 1.77.2 for CRAN's compatibility checks. Neither resolves here: `wbraster` needs rayon `^1.12`, and geo 0.29 pulls `i_float ~1.3` while our geo 0.33 pulls `i_float ~1.16` — same major, disjoint ranges, so the two cannot coexist. The fork ([giswqs/freestiler@b77f7f0](https://github.com/giswqs/freestiler/commit/b77f7f0d76e11bf105e913ab6d553eb2a4a7ca00)) drops those pins and bumps to geo 0.33. This is **not upstreamable** — the required MSRV bump to 1.88 would break CRAN — hence the fork.

Default features only; `duckdb`/`geoparquet` would drag bundled C++ and arrow into the wasm build.

## Notes on the implementation

- **`writer::build_mvt`** joins `build_png`. `assemble` was already generic over tile type; `build_mvt` sets `TILETYPE_MVT` and gzips each tile, since MVT readers expect GZIP where PNG ships as NONE. It takes TileJSON metadata as bytes from the caller so `geolibre-pmtiles` stays free of a JSON dependency — that crate exists to be lightweight.
- **Metadata carries a `vector_layers` array**, without which MapLibre will not style the source.
- **Bounds are clamped to the tiled area.** Data that unwraps across the antimeridian rather than splitting (Alaska reaches -188.9 in the usual US states GeoJSON) would otherwise advertise coverage no tile provides; the tiler clips at the projection edge regardless. Caught by running on real data, and pinned by a regression test.
- **Geometry collections flatten** into one feature per member; degenerate rings/lines are dropped, since the MVT encoder has nothing to emit for them. Blob attributes become null to keep positions aligned with `prop_names`.

## Verification

- 52-feature US states GeoJSON → 183 tiles. **Every tile z0–z6 decodes** under the independent `pmtiles` + `mapbox_vector_tile` Python readers, with correct layer name, extent 4096, and typed properties (`name` String, `density` Number).
- Native and `wasm32-wasip1` output are **byte-identical**, the latter driven through `npm/tools.mjs` exactly as the browser does.
- 71 tests pass across `geolibre-cli`/`geolibre-tools`/`geolibre-pmtiles`, including the `every_tool_has_explicit_param_schemas` guard.
- Shipped wasm: **17.01 MB → 17.66 MB (+3.8%)**, measured with `build.sh`'s own `wasm-opt -Oz` flags against a clean `main` build. Modest because geo and rayon were already in the graph.

## Drive-by

The demo labelled every download `image/tiff`, including the `.pmtiles` that `write_pmtiles` already produced. Now derived from the extension.