### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "0.4.3"
+version = "0.8.0"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -945,14 +945,14 @@ dependencies = [
 
 [[package]]
 name = "geolibre-pmtiles"
-version = "0.4.3"
+version = "0.8.0"
 dependencies = [
  "flate2",
 ]
 
 [[package]]
 name = "geolibre-tools"
-version = "0.4.3"
+version = "0.8.0"
 dependencies = [
  "flate2",
  "freestiler-core",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-wasm"
-version = "0.4.3"
+version = "0.8.0"
 dependencies = [
  "console_error_panic_hook",
  "geolibre-pmtiles",

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "0.4.3"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-pmtiles/Cargo.toml
+++ b/crates/geolibre-pmtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-pmtiles"
-version = "0.4.3"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "0.4.3"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "0.4.3"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "0.4.3",
+  "version": "0.8.0",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolibre-wasm"
-version = "0.4.3"
+version = "0.8.0"
 description = "Run the GeoLibre / whitebox_next_gen geospatial tool suite (WASM/WASI) from Python."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/geolibre_wasm/__init__.py
+++ b/python/src/geolibre_wasm/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "runtime_path",
 ]
 
-__version__ = "0.4.3"
+__version__ = "0.8.0"

--- a/python/src/geolibre_wasm/_core.py
+++ b/python/src/geolibre_wasm/_core.py
@@ -38,7 +38,7 @@ def _http_get(url: str, timeout: int) -> bytes:
 
 #: Release whose ``geolibre-cli.wasm`` asset this wrapper downloads by default.
 #: Kept in sync with the package version's ``vMAJOR.MINOR.PATCH`` tag.
-RUNTIME_VERSION = "v0.4.3"
+RUNTIME_VERSION = "v0.8.0"
 _ASSET = f"geolibre-cli-{RUNTIME_VERSION}.wasm"
 _RELEASE_URL = (
     "https://github.com/opengeos/geolibre-rust/releases/download/"


### PR DESCRIPTION
Version bump ahead of the `v0.8.0` tag, which ships [`vector_to_pmtiles` (#40)](https://github.com/opengeos/geolibre-rust/pull/40). Minor bump follows the repo's convention that a new tool gets one (v0.5.0 for `raster_to_h3`, v0.7.0 for `pmtiles_extract`).

### Why this touches the crates at all

The in-tree versions had sat at **0.4.3** since that release while tags moved on to **v0.7.2**. `release.yml` syncs npm and Python from the tag at publish time and never touches the crates, so nothing caught the drift — and `geolibre version` reports `CARGO_PKG_VERSION`, meaning it has printed `0.4.3` for every release since.

```
$ geolibre version
geolibre-cli 0.8.0     # was: geolibre-cli 0.4.3
```

The npm/Python bumps here are redundant with what the workflow already does (its sync steps pass `--allow-same-version`), but leaving them stale is precisely what let the crates drift unnoticed.

`RUNTIME_VERSION` moves with them, per its own docstring. It resolves to the v0.8.0 release assets, which the tag creates; Python's tests are unaffected because CI points `GEOLIBRE_WASM` at the freshly built runtime instead of downloading.

### Verified

- 71 Rust tests pass; 5 Python tests pass against the freshly built wasm.
- `geolibre version` now reports `0.8.0`.