### PR TITLE
chore: sync whitebox-wasm topology fixes (0.9.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -945,14 +945,14 @@ dependencies = [
 
 [[package]]
 name = "geolibre-pmtiles"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "flate2",
 ]
 
 [[package]]
 name = "geolibre-tools"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "flate2",
  "freestiler-core",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-wasm"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "console_error_panic_hook",
  "geolibre-pmtiles",
@@ -3476,7 +3476,7 @@ dependencies = [
 [[package]]
 name = "wbcore"
 version = "0.1.1"
-source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
+source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
 dependencies = [
  "serde",
  "serde_json",
@@ -3486,7 +3486,7 @@ dependencies = [
 [[package]]
 name = "wbgeotiff"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
+source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -3505,7 +3505,7 @@ dependencies = [
 [[package]]
 name = "wbhdf"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
+source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3516,7 +3516,7 @@ dependencies = [
 [[package]]
 name = "wblidar"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
+source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
 dependencies = [
  "rayon",
  "wbhdf",
@@ -3527,7 +3527,7 @@ dependencies = [
 [[package]]
 name = "wbprojection"
 version = "0.3.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
+source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
 dependencies = [
  "thiserror 1.0.69",
  "wide 1.5.0",
@@ -3536,7 +3536,7 @@ dependencies = [
 [[package]]
 name = "wbraster"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
+source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -3559,7 +3559,7 @@ dependencies = [
 [[package]]
 name = "wbspatialstats"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
+source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
 dependencies = [
  "log",
  "nalgebra",
@@ -3574,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "wbtools_oss"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
+source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
 dependencies = [
  "bincode",
  "chrono",
@@ -3604,7 +3604,7 @@ dependencies = [
 [[package]]
 name = "wbtopology"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
+source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
 dependencies = [
  "rayon",
  "robust",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "wbvector"
 version = "0.1.4"
-source = "git+https://github.com/opengeos/whitebox-wasm#926357467251dc2a71c9cddfbbcf042f87697bf5"
+source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
 dependencies = [
  "bytes",
  "flatbuffers 24.12.23",

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-pmtiles/Cargo.toml
+++ b/crates/geolibre-pmtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-pmtiles"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolibre-wasm"
-version = "0.8.0"
+version = "0.9.0"
 description = "Run the GeoLibre / whitebox_next_gen geospatial tool suite (WASM/WASI) from Python."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/geolibre_wasm/__init__.py
+++ b/python/src/geolibre_wasm/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "runtime_path",
 ]
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/python/src/geolibre_wasm/_core.py
+++ b/python/src/geolibre_wasm/_core.py
@@ -38,7 +38,7 @@ def _http_get(url: str, timeout: int) -> bytes:
 
 #: Release whose ``geolibre-cli.wasm`` asset this wrapper downloads by default.
 #: Kept in sync with the package version's ``vMAJOR.MINOR.PATCH`` tag.
-RUNTIME_VERSION = "v0.8.0"
+RUNTIME_VERSION = "v0.9.0"
 _ASSET = f"geolibre-cli-{RUNTIME_VERSION}.wasm"
 _RELEASE_URL = (
     "https://github.com/opengeos/geolibre-rust/releases/download/"


### PR DESCRIPTION
Pulls in the topology fixes from opengeos/whitebox-wasm#9 and opengeos/whitebox-wasm#10 by updating the git pins to `c2b7319`, and bumps all crate/npm/python versions to 0.9.0.

Verified locally against the rebuilt `geolibre.wasm` (wasm32-wasip1): the valid-square report is empty (bowtie still caught via `polygon_topology_invalid`), near-miss endpoints snap exactly onto their neighbor, spur dangles project onto their line, validate-after-fix reports only genuinely free ends, and the omitted-`dry_run` preview notice prints.

Tagging `v0.9.0` after merge publishes `geolibre-wasm` to npm; GeoLibre bump follows (opengeos/GeoLibre#1290 chain).