### PR TITLE
feat(tools): assign_projection_{raster,vector,lidar}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -945,14 +945,14 @@ dependencies = [
 
 [[package]]
 name = "geolibre-pmtiles"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "flate2",
 ]
 
 [[package]]
 name = "geolibre-tools"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "flate2",
  "freestiler-core",
@@ -963,13 +963,14 @@ dependencies = [
  "png 0.17.16",
  "serde_json",
  "wbcore",
+ "wblidar",
  "wbraster",
  "wbvector",
 ]
 
 [[package]]
 name = "geolibre-wasm"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "console_error_panic_hook",
  "geolibre-pmtiles",

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ rendering tools that the whitebox suite lacks (all pure-Rust, running in WASM):
 | Tool id | What it does |
 |---|---|
 | `reproject_raster` | Reproject (warp) a raster into a target EPSG CRS, with selectable resampling. |
+| `assign_projection_raster` | Assign an EPSG CRS to a raster's metadata without warping its cells (for data whose coordinates are already in that CRS but carry a missing/wrong projection tag). |
+| `assign_projection_vector` | Assign an EPSG CRS to a vector layer without reprojecting its geometries. |
+| `assign_projection_lidar` | Assign an EPSG CRS to a LiDAR point cloud (LAS/LAZ/COPC) without reprojecting its points. |
 | `render_raster_png` | Render a raster band to a PNG through a colormap (viridis/magma/turbo/terrain/grayscale); no-data becomes transparent. |
 | `raster_to_tiles` | Slice a raster into a Web Mercator (EPSG:3857) XYZ PNG tile pyramid for web maps. |
 | `write_pmtiles` | Render a raster into a single PMTiles archive (the Web Mercator PNG pyramid as one file). |

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-pmtiles/Cargo.toml
+++ b/crates/geolibre-pmtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-pmtiles"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,6 +15,8 @@ wbcore = { git = "https://github.com/opengeos/whitebox-wasm" }
 wbraster = { git = "https://github.com/opengeos/whitebox-wasm" }
 # GeoParquet read/write lives behind wbvector's `geoparquet` feature.
 wbvector = { git = "https://github.com/opengeos/whitebox-wasm", features = ["geoparquet"] }
+# LAS/LAZ/COPC point-cloud I/O for the LiDAR assign-projection tool.
+wblidar = { git = "https://github.com/opengeos/whitebox-wasm" }
 # Pulled in transitively by wbvector's geoparquet feature; named directly so the
 # GeoParquet tools can choose the compression codec (ZSTD by default).
 parquet = "58.3"

--- a/crates/geolibre-tools/src/assign_projection.rs
+++ b/crates/geolibre-tools/src/assign_projection.rs
@@ -1,0 +1,322 @@
+//! GeoLibre tools: assign a coordinate reference system to a raster, vector, or
+//! LiDAR dataset **without** transforming its coordinates.
+//!
+//! The whitebox catalog advertises `assign_projection_{raster,vector,lidar}` but
+//! the WASM binary never implemented them, so in GeoLibre's local (WASM) mode
+//! they rendered a dead-end form with no parameters (GeoLibre#1355). These
+//! implementations fill that gap. Unlike `reproject_*` (which warps the grid /
+//! reprojects geometries), assign-projection only rewrites the stored CRS
+//! metadata to the given EPSG code, for datasets whose coordinates are already
+//! in that CRS but that carry a missing or wrong projection tag.
+
+use serde_json::{json, Value};
+use wbcore::{
+    LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata,
+    ToolParamSpec, ToolRunResult,
+};
+use wbraster::CrsInfo;
+
+use crate::common::{load_input_raster, parse_optional_output, write_or_store_output};
+use crate::lidar_common::{load_input_cloud, write_or_store_cloud};
+use crate::vector_common::{load_input_layer, parse_optional_str, write_or_store_layer};
+
+/// The three `input`/`epsg`/`output` parameter specs shared by every
+/// assign-projection tool. `kind` names the dataset in the descriptions.
+fn assign_params(kind: &'static str) -> Vec<ToolParamSpec> {
+    let input_desc: &'static str = match kind {
+        "raster" => "Input raster file path (or in-memory handle).",
+        "vector" => "Input vector file path, format auto-detected (or in-memory handle).",
+        _ => "Input LiDAR file path (LAS/LAZ/COPC, or in-memory handle).",
+    };
+    let output_desc: &'static str = match kind {
+        "raster" => {
+            "Optional output raster path. If omitted, the result is stored in memory."
+        }
+        "vector" => {
+            "Optional output vector path (driver from its extension). If omitted, stored in memory."
+        }
+        _ => "Optional output LiDAR path. If omitted, the result is stored in memory.",
+    };
+    vec![
+        ToolParamSpec {
+            name: "input",
+            description: input_desc,
+            required: true,
+        },
+        ToolParamSpec {
+            name: "epsg",
+            description: "EPSG code of the CRS to assign, e.g. 4326 (WGS84) or 3857 (Web Mercator). Coordinates are not transformed.",
+            required: true,
+        },
+        ToolParamSpec {
+            name: "output",
+            description: output_desc,
+            required: false,
+        },
+    ]
+}
+
+/// Validates that `input` is a non-empty string and `epsg` is a positive code.
+fn validate_assign(args: &ToolArgs) -> Result<(), ToolError> {
+    if args
+        .get("input")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or("")
+        .is_empty()
+    {
+        return Err(ToolError::Validation(
+            "missing required string parameter 'input'".to_string(),
+        ));
+    }
+    parse_epsg(args)?;
+    Ok(())
+}
+
+/// Reads the required `input` path parameter.
+fn input_path(args: &ToolArgs) -> Result<&str, ToolError> {
+    args.get("input")
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| ToolError::Validation("missing required parameter 'input'".to_string()))
+}
+
+/// Assigns a CRS to a raster's metadata without warping the grid.
+pub struct AssignProjectionRasterTool;
+
+impl Tool for AssignProjectionRasterTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "assign_projection_raster",
+            display_name: "Assign Projection Raster",
+            summary: "Assign a coordinate reference system to a raster without warping its cells.",
+            category: ToolCategory::Raster,
+            license_tier: LicenseTier::Open,
+            params: assign_params("raster"),
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        validate_assign(args)
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = input_path(args)?;
+        let epsg = parse_epsg(args)?;
+        let output = parse_optional_output(args, "output")?;
+
+        let mut raster = load_input_raster(input)?;
+        ctx.progress.info(&format!("assigning EPSG:{epsg}"));
+        raster.crs = CrsInfo::from_epsg(epsg);
+        let (rows, cols) = (raster.rows, raster.cols);
+        let out_path = write_or_store_output(raster, output)?;
+
+        let mut outputs = std::collections::BTreeMap::new();
+        outputs.insert("output".to_string(), json!(out_path));
+        outputs.insert("epsg".to_string(), json!(epsg));
+        outputs.insert("rows".to_string(), json!(rows));
+        outputs.insert("cols".to_string(), json!(cols));
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+/// Assigns a CRS to a vector layer's metadata without reprojecting geometries.
+pub struct AssignProjectionVectorTool;
+
+impl Tool for AssignProjectionVectorTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "assign_projection_vector",
+            display_name: "Assign Projection Vector",
+            summary: "Assign a coordinate reference system to a vector layer without reprojecting its geometries.",
+            category: ToolCategory::Vector,
+            license_tier: LicenseTier::Open,
+            params: assign_params("vector"),
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        validate_assign(args)
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = input_path(args)?;
+        let epsg = parse_epsg(args)?;
+        let output = parse_optional_str(args, "output")?;
+
+        let mut layer = load_input_layer(input)?;
+        ctx.progress.info(&format!("assigning EPSG:{epsg}"));
+        layer.assign_crs_epsg(epsg);
+        let feature_count = layer.len();
+        let out_path = write_or_store_layer(layer, output)?;
+
+        let mut outputs = std::collections::BTreeMap::new();
+        outputs.insert("output".to_string(), json!(out_path));
+        outputs.insert("epsg".to_string(), json!(epsg));
+        outputs.insert("feature_count".to_string(), json!(feature_count));
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+/// Assigns a CRS to a LiDAR point cloud's metadata without reprojecting points.
+pub struct AssignProjectionLidarTool;
+
+impl Tool for AssignProjectionLidarTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            id: "assign_projection_lidar",
+            display_name: "Assign Projection Lidar",
+            summary: "Assign a coordinate reference system to a LiDAR point cloud without reprojecting its points.",
+            category: ToolCategory::Lidar,
+            license_tier: LicenseTier::Open,
+            params: assign_params("lidar"),
+        }
+    }
+
+    fn validate(&self, args: &ToolArgs) -> Result<(), ToolError> {
+        validate_assign(args)
+    }
+
+    fn run(&self, args: &ToolArgs, ctx: &ToolContext) -> Result<ToolRunResult, ToolError> {
+        let input = input_path(args)?;
+        let epsg = parse_epsg(args)?;
+        let output = parse_optional_str(args, "output")?;
+
+        let mut cloud = load_input_cloud(input)?;
+        ctx.progress.info(&format!("assigning EPSG:{epsg}"));
+        cloud.assign_crs_epsg(epsg);
+        let point_count = cloud.point_count();
+        let out_path = write_or_store_cloud(cloud, output)?;
+
+        let mut outputs = std::collections::BTreeMap::new();
+        outputs.insert("output".to_string(), json!(out_path));
+        outputs.insert("epsg".to_string(), json!(epsg));
+        outputs.insert("point_count".to_string(), json!(point_count));
+        Ok(ToolRunResult { outputs })
+    }
+}
+
+/// Parses the required positive `epsg` parameter (accepts a number or a numeric
+/// string). Shared by every assign-projection tool.
+fn parse_epsg(args: &ToolArgs) -> Result<u32, ToolError> {
+    let raw = args
+        .get("epsg")
+        .ok_or_else(|| ToolError::Validation("missing required parameter 'epsg'".to_string()))?;
+    let code = match raw {
+        Value::Number(n) => n.as_u64(),
+        Value::String(s) => s.trim().parse::<u64>().ok(),
+        _ => None,
+    };
+    match code {
+        Some(c) if c > 0 && c <= u32::MAX as u64 => Ok(c as u32),
+        _ => Err(ToolError::Validation(
+            "parameter 'epsg' must be a positive EPSG code".to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wbcore::{AllowAllCapabilities, ProgressSink};
+
+    struct NullProgress;
+    impl ProgressSink for NullProgress {}
+
+    fn ctx() -> ToolContext<'static> {
+        ToolContext {
+            progress: &NullProgress,
+            capabilities: &AllowAllCapabilities,
+        }
+    }
+
+    fn args(input: &str, epsg: Value) -> ToolArgs {
+        serde_json::from_value(json!({ "input": input, "epsg": epsg })).unwrap()
+    }
+
+    #[test]
+    fn assigns_crs_to_a_raster_without_warping() {
+        use wbraster::{DataType, Raster, RasterConfig};
+        let cfg = RasterConfig {
+            cols: 2,
+            rows: 1,
+            bands: 1,
+            x_min: 0.0,
+            y_min: 0.0,
+            cell_size: 1.0,
+            cell_size_y: Some(1.0),
+            nodata: -9999.0,
+            data_type: DataType::F64,
+            // Start mislabeled as 4326 to prove the tool overwrites it.
+            crs: CrsInfo::from_epsg(4326),
+            metadata: Vec::new(),
+        };
+        let raster = Raster::from_data(cfg, vec![1.0, 2.0]).unwrap();
+        let id = wbraster::memory_store::put_raster(raster);
+        let input = wbraster::memory_store::make_raster_memory_path(&id);
+
+        let out = AssignProjectionRasterTool
+            .run(&args(&input, json!(32610)), &ctx())
+            .unwrap();
+        assert_eq!(out.outputs["epsg"], json!(32610));
+
+        let result = load_input_raster(out.outputs["output"].as_str().unwrap()).unwrap();
+        assert_eq!(result.crs.epsg, Some(32610));
+        // The grid is untouched: same cells, same values.
+        assert_eq!((result.rows, result.cols), (1, 2));
+        assert_eq!(result.get(0, 0, 0), 1.0);
+        assert_eq!(result.get(0, 0, 1), 2.0);
+    }
+
+    #[test]
+    fn assigns_crs_to_a_vector_layer() {
+        use wbvector::{memory_store, Layer};
+        let mut layer = Layer::new("test");
+        layer.set_crs_epsg(Some(4326));
+        let id = memory_store::put_vector(layer);
+        let input = memory_store::make_vector_memory_path(&id);
+
+        let out = AssignProjectionVectorTool
+            .run(&args(&input, json!(3857)), &ctx())
+            .unwrap();
+        assert_eq!(out.outputs["epsg"], json!(3857));
+
+        let result =
+            crate::vector_common::load_input_layer(out.outputs["output"].as_str().unwrap()).unwrap();
+        assert_eq!(result.crs_epsg(), Some(3857));
+    }
+
+    #[test]
+    fn assigns_crs_to_a_point_cloud() {
+        use wblidar::{memory_store, point::PointRecord, PointCloud};
+        let cloud = PointCloud {
+            points: vec![PointRecord::default(), PointRecord::default()],
+            crs: None,
+        };
+        let id = memory_store::put_lidar(cloud);
+        let input = memory_store::make_lidar_memory_path(&id);
+
+        let out = AssignProjectionLidarTool
+            .run(&args(&input, json!(26910)), &ctx())
+            .unwrap();
+        assert_eq!(out.outputs["epsg"], json!(26910));
+        assert_eq!(out.outputs["point_count"], json!(2));
+
+        let result =
+            crate::lidar_common::load_input_cloud(out.outputs["output"].as_str().unwrap()).unwrap();
+        assert_eq!(result.crs.and_then(|c| c.epsg), Some(26910));
+    }
+
+    #[test]
+    fn rejects_missing_input_and_bad_epsg() {
+        let missing: ToolArgs = serde_json::from_value(json!({ "epsg": 4326 })).unwrap();
+        assert!(AssignProjectionVectorTool.validate(&missing).is_err());
+
+        let bad_epsg = args("memory://vector/whatever", json!(0));
+        assert!(AssignProjectionRasterTool.validate(&bad_epsg).is_err());
+
+        let str_epsg = args("memory://vector/whatever", json!("32610"));
+        // A numeric string is accepted by parse_epsg, so validation passes.
+        assert!(AssignProjectionLidarTool.validate(&str_epsg).is_ok());
+    }
+}

--- a/crates/geolibre-tools/src/lib.rs
+++ b/crates/geolibre-tools/src/lib.rs
@@ -7,6 +7,7 @@
 //! Add a new tool by creating a module with a `Tool` impl and pushing it in
 //! [`geolibre_tools`].
 
+mod assign_projection;
 mod common;
 mod delineate_depressions;
 mod delineate_mounts;
@@ -17,6 +18,7 @@ mod geoparquet_io;
 mod h3_polyfill;
 mod h3_to_vector;
 mod hilbert;
+mod lidar_common;
 mod polygonize;
 mod pmtiles;
 mod pmtiles_extract;
@@ -53,6 +55,9 @@ use wbcore::{Tool, ToolDatasetSchema, ToolParamSchema};
 /// ```
 pub fn geolibre_tools() -> Vec<Box<dyn Tool>> {
     vec![
+        Box::new(assign_projection::AssignProjectionRasterTool),
+        Box::new(assign_projection::AssignProjectionVectorTool),
+        Box::new(assign_projection::AssignProjectionLidarTool),
         Box::new(raster_normalize::RasterNormalizeTool),
         Box::new(dem_filter::DemFilterTool),
         Box::new(extract_sinks::ExtractSinksTool),
@@ -99,6 +104,8 @@ pub fn geolibre_param_schemas(tool_id: &str) -> Option<BTreeMap<String, ToolPara
     let vector_out = ToolParamSchema::output_vector_any;
     let file_out = || ToolParamSchema::output(ToolDatasetSchema::File);
     let table_out = || ToolParamSchema::output(ToolDatasetSchema::Table);
+    let lidar_in = ToolParamSchema::input_lidar;
+    let lidar_out = || ToolParamSchema::output(ToolDatasetSchema::Lidar);
     let int = ToolParamSchema::scalar_integer;
     let float = ToolParamSchema::scalar_float;
     let colormaps = || {
@@ -106,6 +113,21 @@ pub fn geolibre_param_schemas(tool_id: &str) -> Option<BTreeMap<String, ToolPara
     };
 
     let map = match tool_id {
+        "assign_projection_raster" => schemas(&[
+            ("input", raster_in()),
+            ("epsg", int()),
+            ("output", raster_out()),
+        ]),
+        "assign_projection_vector" => schemas(&[
+            ("input", vector_in()),
+            ("epsg", int()),
+            ("output", vector_out()),
+        ]),
+        "assign_projection_lidar" => schemas(&[
+            ("input", lidar_in()),
+            ("epsg", int()),
+            ("output", lidar_out()),
+        ]),
         "raster_normalize" => schemas(&[
             ("input", raster_in()),
             ("output", raster_out()),

--- a/crates/geolibre-tools/src/lidar_common.rs
+++ b/crates/geolibre-tools/src/lidar_common.rs
@@ -1,0 +1,51 @@
+//! Shared LiDAR I/O for GeoLibre tools: load a `PointCloud` from a file path or
+//! an in-memory (`memory://`) handle, and write it back to a path or memory.
+//!
+//! Mirrors `common.rs` (raster) and `vector_common.rs` (vector) but for
+//! `wblidar::PointCloud`.
+
+use std::sync::Arc;
+
+use wbcore::ToolError;
+use wblidar::{memory_store, PointCloud};
+
+/// Loads a point cloud from a file path (LAS/LAZ/COPC, format auto-detected) or
+/// an in-memory (`memory://`) handle.
+pub fn load_input_cloud(path: &str) -> Result<PointCloud, ToolError> {
+    if memory_store::lidar_is_memory_path(path) {
+        let id = memory_store::lidar_path_to_id(path)
+            .ok_or_else(|| ToolError::Validation("malformed in-memory lidar path".to_string()))?;
+        let arc: Arc<PointCloud> = memory_store::get_lidar_arc_by_id(id)
+            .ok_or_else(|| ToolError::Validation(format!("unknown in-memory lidar id '{id}'")))?;
+        return Ok((*arc).clone());
+    }
+    PointCloud::read(path)
+        .map_err(|e| ToolError::Execution(format!("failed reading input lidar: {e}")))
+}
+
+/// Writes `cloud` to `output_path` using the format implied by its extension, or
+/// stores it in memory and returns a `memory://` handle when no path is given.
+pub fn write_or_store_cloud(
+    cloud: PointCloud,
+    output_path: Option<&str>,
+) -> Result<String, ToolError> {
+    match output_path {
+        Some(path) => {
+            if let Some(parent) = std::path::Path::new(path).parent() {
+                if !parent.as_os_str().is_empty() {
+                    std::fs::create_dir_all(parent).map_err(|e| {
+                        ToolError::Execution(format!("failed creating output directory: {e}"))
+                    })?;
+                }
+            }
+            cloud
+                .write(path)
+                .map_err(|e| ToolError::Execution(format!("failed writing output lidar: {e}")))?;
+            Ok(path.to_string())
+        }
+        None => {
+            let id = memory_store::put_lidar(cloud);
+            Ok(memory_store::make_lidar_memory_path(&id))
+        }
+    }
+}

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolibre-wasm"
-version = "0.9.0"
+version = "0.10.0"
 description = "Run the GeoLibre / whitebox_next_gen geospatial tool suite (WASM/WASI) from Python."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/geolibre_wasm/__init__.py
+++ b/python/src/geolibre_wasm/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "runtime_path",
 ]
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"


### PR DESCRIPTION
## Summary

The `whitebox_next_gen` catalog advertises `assign_projection_raster`, `assign_projection_vector`, and `assign_projection_lidar`, but the `whitebox-wasm` fork never implemented them, so they are absent from the WASI runner. In GeoLibre's local (WASM) mode they surface from the catalog with **no parameters** ("This tool has no parameters") and fail on Run with `tool not found` (opengeos/GeoLibre#1355).

This implements all three as GeoLibre-authored tools, the same way `geolibre-tools` already fills gaps the whitebox suite leaves (e.g. `reproject_raster`, whose header notes *"The whitebox suite ships `reproject_vector` but no raster warp; this fills that gap."*).

Unlike `reproject_*`, assign-projection only **rewrites the stored CRS metadata** to the given EPSG code **without transforming coordinates** — for datasets whose coordinates are already in that CRS but that carry a missing or wrong projection tag.

## What's in it

- `assign_projection_raster` — `raster.crs = CrsInfo::from_epsg(epsg)`
- `assign_projection_vector` — `Layer::assign_crs_epsg(epsg)`
- `assign_projection_lidar` — `PointCloud::assign_crs_epsg(epsg)`
- Each takes `input`, `epsg` (required), and an optional `output`; explicit param schemas so the manifest carries accurate `io_role`/`data_kind`.
- New `lidar_common` I/O helper (mirrors `common`/`vector_common`) + a `wblidar` dependency on `geolibre-tools`.
- Unit tests for all three, including a LAS CRS write/read roundtrip, plus validation.
- Minor version bump to `0.10.0`.

## Verification

- `cargo test -p geolibre-tools -p geolibre-cli` green (new tests included).
- Manifests: each tool reports `input` / `epsg` / `output` with the right dataset kinds and `source: geolibre`.
- CLI on real data: vector identity (assign 4326 leaves coords unchanged), vector projected (assign 32610 to UTM easting/northing reprojects to correct lon/lat on GeoJSON write), FlatGeobuf roundtrip preserves the assigned CRS, raster and LAS runs succeed.
- Rebuilt `geolibre.wasm` swapped into GeoLibre: the three tools now render input/EPSG/output fields (light + dark themes) and run to a successful output layer.

Fixes the engine side of opengeos/GeoLibre#1355; the GeoLibre PR bumps `geolibre-wasm` to consume it.