### PR TITLE
fix(demo): default output filename from dataset kind, not .tif

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -117,15 +117,29 @@
 
       // Default filename for an output param. Don't assume .tif: prefer the
       // worked example value, then the "e.g. <path>" in the description (which
-      // carries the right extension, e.g. .parquet/.png, or a dir like tiles),
-      // then any ".ext" mentioned, and only then fall back to .tif.
+      // carries the right exact format, e.g. .parquet/.png, or a dir like
+      // tiles), then any ".ext" mentioned, then the manifest's dataset kind
+      // (a vector output defaults to .geojson, LiDAR to .laz, a table to
+      // .csv), and only then fall back to .tif.
       function outputDefault(tool, param, hint) {
         if (hint != null && String(hint).includes(".")) return basename(String(hint));
         const desc = param.description || "";
         const eg = desc.match(/e\.g\.?\s+([^\s,)]+)/i);
         if (eg) return basename(eg[1]);
         const ext = desc.match(/\.([a-z0-9]{2,8})\b/i);
-        return `${tool.id}.${ext ? ext[1] : "tif"}`;
+        if (ext) return `${tool.id}.${ext[1]}`;
+        if (/html/i.test(param.name)) return `${tool.id}.html`;
+        const KIND_EXT = {
+          vector: "geojson",
+          raster: "tif",
+          lidar: "laz",
+          table: "csv",
+          json: "json",
+          text: "txt",
+        };
+        const kind =
+          param.data_kind ?? (param.schema && param.schema.dataset && param.schema.dataset.kind);
+        return `${tool.id}.${KIND_EXT[kind] ?? "tif"}`;
       }
 
       // Best-known value for a param: prefer the worked example, fall back to the default.


### PR DESCRIPTION
## Summary
- The demo tool form fell back to `<tool_id>.tif` for any output param whose description lacked an example extension, so vector tools (e.g. `regularize_building_footprints`, `assign_projection_vector`) suggested a raster filename.
- The default now consults the manifest's `data_kind`/schema when description heuristics find nothing: vector outputs default to `.geojson`, LiDAR to `.laz`, tables to `.csv`, and json/text report outputs to `.json`/`.txt`; `.tif` remains the fallback for rasters.

## Test plan
- [x] Simulated the new logic in Node against all 695 output params in the full tool catalog: zero non-raster outputs default to `.tif` anymore, and raster/file outputs keep their previous defaults
- [x] `regularize_building_footprints` output now defaults to `regularize_building_footprints.geojson`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default output filename detection using examples and parameter metadata.
  * Added format-aware extensions for vector, raster, lidar, table, JSON, and text outputs.
  * HTML outputs now default to the tool’s name with an `.html` extension.
  * Retained a reliable fallback extension when no format information is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->