### PR TITLE
chore(release): bump version to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -945,14 +945,14 @@ dependencies = [
 
 [[package]]
 name = "geolibre-pmtiles"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "flate2",
 ]
 
 [[package]]
 name = "geolibre-tools"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "flate2",
  "freestiler-core",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-wasm"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "console_error_panic_hook",
  "geolibre-pmtiles",

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-pmtiles/Cargo.toml
+++ b/crates/geolibre-pmtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-pmtiles"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolibre-wasm"
-version = "0.10.0"
+version = "0.11.0"
 description = "Run the GeoLibre / whitebox_next_gen geospatial tool suite (WASM/WASI) from Python."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/geolibre_wasm/__init__.py
+++ b/python/src/geolibre_wasm/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "runtime_path",
 ]
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"


### PR DESCRIPTION
## Summary
- Bump all workspace crates, the npm package, and the Python package from 0.10.0 to 0.11.0.
- Minor bump for the two new tools since v0.10.0: regularize_building_footprints (#44) and smooth_natural_features (#46).

## Test plan
- [x] cargo check --workspace passes after the bump
- [ ] CI passes
- [ ] After merge, publish the v0.11.0 GitHub release