### PR TITLE
ci: per-PR GitHub Pages previews for the browser demo

### DIFF
--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -1,0 +1,87 @@
+name: PR preview (GitHub Pages)
+
+# Builds the browser demo for every pull request and publishes it to the
+# `gh-pages` branch under `pr-preview/pr-<N>/`, then posts (and keeps updated) a
+# sticky comment with the URL. The preview is removed automatically when the PR
+# is closed or merged.
+#
+# Production (pages.yml) lives at the root of the same `gh-pages` branch and uses
+# `keep_files: true`, so production and every preview coexist on one Pages site:
+#   production:  https://opengeos.github.io/geolibre-rust/
+#   preview #N:  https://opengeos.github.io/geolibre-rust/pr-preview/pr-<N>/
+#
+# No external secrets are needed — this uses the built-in GITHUB_TOKEN.
+#
+# NOTE on fork PRs: forks do not get a write-scoped token, so the deploy to
+# gh-pages would fail. The job guard below skips fork PRs; previews run only for
+# branches pushed to this repo (maintainers and collaborators).
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, closed]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pages-preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Build and deploy preview
+    runs-on: ubuntu-latest
+    # Skip fork PRs: they can't push to gh-pages, so the deploy would fail.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: github.event.action != 'closed'
+        with:
+          targets: wasm32-wasip1, wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        if: github.event.action != 'closed'
+
+      - name: Install wasm-pack
+        if: github.event.action != 'closed'
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Install binaryen (wasm-opt)
+        if: github.event.action != 'closed'
+        run: sudo apt-get update && sudo apt-get install -y binaryen
+
+      - name: Install wasi-sdk (C toolchain so zstd-sys builds for wasm32-wasip1)
+        if: github.event.action != 'closed'
+        run: |
+          ver=33.0
+          curl -sL "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-${ver}-x86_64-linux.tar.gz" | sudo tar xz -C /opt
+          sdk=/opt/wasi-sdk-${ver}-x86_64-linux
+          echo "CC_wasm32_wasip1=$sdk/bin/clang" >> "$GITHUB_ENV"
+          echo "AR_wasm32_wasip1=$sdk/bin/llvm-ar" >> "$GITHUB_ENV"
+          echo "CFLAGS_wasm32_wasip1=--sysroot=$sdk/share/wasi-sysroot" >> "$GITHUB_ENV"
+
+      - name: Build both WASM artifacts and assemble the site
+        if: github.event.action != 'closed'
+        run: |
+          ./build.sh
+          mkdir -p site
+          cp demo/index.html           site/index.html
+          cp npm/tools.mjs             site/tools.mjs
+          cp npm/geolibre-cli.wasm     site/geolibre-cli.wasm
+          cp npm/geolibre_wasm.js      site/geolibre_wasm.js
+          cp npm/geolibre_wasm_bg.wasm site/geolibre_wasm_bg.wasm
+          cp examples/sample.tif       site/sample.tif
+          # cache-bust the glue + wasm together (unique per commit)
+          sed -i "s/__BUILD__/${GITHUB_SHA}/g" site/index.html
+
+      - name: Deploy preview to gh-pages (pr-preview/pr-<N>/)
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./site
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview

--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -6,9 +6,11 @@ name: PR preview (GitHub Pages)
 # is closed or merged.
 #
 # Production (pages.yml) lives at the root of the same `gh-pages` branch and uses
-# `keep_files: true`, so production and every preview coexist on one Pages site:
-#   production:  https://opengeos.github.io/geolibre-rust/
-#   preview #N:  https://opengeos.github.io/geolibre-rust/pr-preview/pr-<N>/
+# `keep_files: true`, so production and every preview coexist on one Pages site.
+# The site is served from the org custom domain (opengeos.github.io inherits
+# opengeos.org), so:
+#   production:  https://opengeos.org/geolibre-rust/
+#   preview #N:  https://opengeos.org/geolibre-rust/pr-preview/pr-<N>/
 #
 # No external secrets are needed — this uses the built-in GITHUB_TOKEN.
 #
@@ -85,3 +87,8 @@ jobs:
           source-dir: ./site
           preview-branch: gh-pages
           umbrella-dir: pr-preview
+          # Serve from the org custom domain so the comment links to
+          # https://opengeos.org/geolibre-rust/pr-preview/pr-<N>/ rather than the
+          # default *.github.io URL. The action posts (and updates) a sticky PR
+          # comment with this URL on every run, and removes it when the PR closes.
+          pages-base-url: opengeos.org/geolibre-rust

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,14 +1,24 @@
 name: Deploy demo to Pages
 
+# Production deploy of the browser demo. It publishes to the root of the
+# `gh-pages` branch (served at https://opengeos.github.io/geolibre-rust/).
+#
+# Per-PR previews (see pages-preview.yml) publish to `pr-preview/pr-<N>/` on the
+# SAME branch, so production and every preview share one repo, one branch and
+# one Pages site. `keep_files: true` below is what makes that coexistence work:
+# a production deploy overwrites the demo files at the root but leaves the
+# `pr-preview/` subtree untouched, so open previews survive a push to main.
+#
+# One-time setup (repo admin): Settings -> Pages -> Build and deployment ->
+# Source = "Deploy from a branch" -> Branch = gh-pages / (root).
+
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: pages
@@ -55,17 +65,15 @@ jobs:
           # an old cached loader with a freshly built module
           sed -i "s/__BUILD__/${GITHUB_SHA}/g" site/index.html
 
-      - uses: actions/configure-pages@v6
-      - uses: actions/upload-pages-artifact@v5
+      - name: Publish to gh-pages (root)
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: site
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v5
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: gh-pages
+          # Overwrite the demo files but preserve the pr-preview/ subtree so open
+          # PR previews are not wiped by a production deploy.
+          keep_files: true
+          user_name: "github-actions[bot]"
+          user_email: "github-actions[bot]@users.noreply.github.com"
+          commit_message: "deploy: ${{ github.sha }}"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,7 +1,8 @@
 name: Deploy demo to Pages
 
 # Production deploy of the browser demo. It publishes to the root of the
-# `gh-pages` branch (served at https://opengeos.github.io/geolibre-rust/).
+# `gh-pages` branch, served from the org custom domain (opengeos.github.io
+# inherits opengeos.org) at https://opengeos.org/geolibre-rust/.
 #
 # Per-PR previews (see pages-preview.yml) publish to `pr-preview/pr-<N>/` on the
 # SAME branch, so production and every preview share one repo, one branch and


### PR DESCRIPTION
Adds per-PR **browser previews of the demo on GitHub Pages** — so any tool change (e.g. #62's `eliminate_polygons`) can be exercised in the real WASI runner from a PR URL — while keeping production and previews in **one repo, one branch, one Pages site**.

## How it works

- **`pages-preview.yml`** (new): on every PR it runs the same build as production (`build.sh` → assemble `site/`) and publishes it to the `gh-pages` branch under `pr-preview/pr-<N>/` via [`rossjrw/pr-preview-action`](https://github.com/rossjrw/pr-preview-action). It posts (and keeps updated) a **sticky comment with the preview URL on the PR**, and removes the preview automatically when the PR is closed or merged.
- **`pages.yml`** (migrated): production now publishes to the **root** of the same `gh-pages` branch (`peaceiris/actions-gh-pages`, `keep_files: true`) instead of the Actions-based Pages deployment. `keep_files: true` lets a push to `main` refresh the demo at the root without wiping open `pr-preview/` subtrees.

The site is served from the org custom domain (`opengeos.github.io` inherits `opengeos.org`):

```
production:  https://opengeos.org/geolibre-rust/
preview #N:  https://opengeos.org/geolibre-rust/pr-preview/pr-<N>/
```

`pr-preview-action`'s `pages-base-url` is set to `opengeos.org/geolibre-rust` so the comment links to the custom-domain URL rather than the default `*.github.io` one. No `CNAME` file is added — this repo's own Pages `cname` is null (the domain is inherited from the org site), so nothing needs preserving on the branch.

- **No external secrets** — uses the built-in `GITHUB_TOKEN`, so there's no 25 MiB/file Cloudflare Pages limit to worry about as the tool suite (and `geolibre-cli.wasm`, ~21 MB today) grows. GitHub Pages allows up to 100 MB/file and ~1 GB/site.
- **Fork PRs are skipped** (they get no write-scoped token); previews run for branches pushed to this repo.

## One-time setup required (repo admin)

After merging, switch the Pages source to the branch this now deploys:

**Settings → Pages → Build and deployment → Source = "Deploy from a branch" → Branch = `gh-pages` / `(root)`**

The site stays at `https://opengeos.org/geolibre-rust/` (the org custom domain is unaffected — only the deployment source changes). The `gh-pages` branch is created automatically by the first deploy; until the source is flipped, the workflows still run and push to `gh-pages`, but the site keeps serving the previous deployment (no downtime).

## Notes

- YAML validated locally; the build steps are copied verbatim from the existing production `pages.yml`, so previews build exactly what ships.
- Once merged, pushing to an open PR (e.g. #62) triggers its preview and comments the URL — so `eliminate_polygons` can be run in the browser from that link.
