### PR TITLE
chore(tools): clippy cleanup for round-4 tools

### DIFF
--- a/crates/geolibre-tools/src/collapse_hydro_polygon.rs
+++ b/crates/geolibre-tools/src/collapse_hydro_polygon.rs
@@ -321,7 +321,7 @@ fn parse_params(args: &ToolArgs) -> Result<Params, ToolError> {
             ))
         }
     };
-    if !(collapse_width > 0.0) {
+    if collapse_width <= 0.0 || collapse_width.is_nan() {
         return Err(ToolError::Validation(
             "'collapse_width' must be positive".into(),
         ));

--- a/crates/geolibre-tools/src/dice.rs
+++ b/crates/geolibre-tools/src/dice.rs
@@ -23,7 +23,7 @@ use wbcore::{
     LicenseTier, Tool, ToolArgs, ToolCategory, ToolContext, ToolError, ToolMetadata, ToolParamSpec,
     ToolRunResult,
 };
-use wbvector::{Coord, Feature, Geometry, GeometryType, Layer, Ring};
+use wbvector::{Coord, Feature, Geometry, Layer, Ring};
 
 use crate::vector_common::{load_input_layer, parse_optional_str, write_or_store_layer};
 
@@ -450,7 +450,7 @@ fn parse_vertex_limit(args: &ToolArgs) -> Result<usize, ToolError> {
 mod tests {
     use super::*;
     use wbcore::{AllowAllCapabilities, ProgressSink};
-    use wbvector::{memory_store, FieldDef, FieldType};
+    use wbvector::{memory_store, FieldDef, FieldType, GeometryType};
 
     struct NullProgress;
     impl ProgressSink for NullProgress {}

--- a/crates/geolibre-tools/src/edgematch_features.rs
+++ b/crates/geolibre-tools/src/edgematch_features.rs
@@ -282,7 +282,7 @@ fn parse_params(args: &ToolArgs) -> Result<Params, ToolError> {
             ))
         }
     };
-    if !(tolerance > 0.0) {
+    if tolerance <= 0.0 || tolerance.is_nan() {
         return Err(ToolError::Validation("'tolerance' must be positive".into()));
     }
     let method = match args.get("method").and_then(Value::as_str).map(str::trim) {

--- a/crates/geolibre-tools/src/local_outlier_analysis.rs
+++ b/crates/geolibre-tools/src/local_outlier_analysis.rs
@@ -225,6 +225,7 @@ impl Tool for LocalOutlierAnalysisTool {
         out.add_field(FieldDef::new("mean_i", FieldType::Float));
 
         let mut total_outliers = 0i64;
+        #[allow(clippy::needless_range_loop)]
         for ci in 0..n_cells {
             let mut counts = [0i64; 4]; // HH, LL, HL, LH
             let mut mean_i = 0.0;

--- a/crates/geolibre-tools/src/time_series_forecast.rs
+++ b/crates/geolibre-tools/src/time_series_forecast.rs
@@ -259,6 +259,7 @@ fn holt(series: &[f64], h: usize) -> Vec<f64> {
     (1..=h).map(|k| level + k as f64 * trend).collect()
 }
 
+#[allow(clippy::needless_range_loop)]
 fn holt_fit(series: &[f64]) -> Vec<f64> {
     let (alpha, beta) = best_holt_params(series);
     let n = series.len();
@@ -274,6 +275,7 @@ fn holt_fit(series: &[f64]) -> Vec<f64> {
     fit
 }
 
+#[allow(clippy::needless_range_loop)]
 fn holt_state(series: &[f64], alpha: f64, beta: f64) -> (f64, f64) {
     let n = series.len();
     let mut level = series[0];
@@ -302,6 +304,7 @@ fn best_holt_params(series: &[f64]) -> (f64, f64) {
     best
 }
 
+#[allow(clippy::needless_range_loop)]
 fn holt_insample_sse(series: &[f64], alpha: f64, beta: f64) -> f64 {
     let n = series.len();
     let mut level = series[0];
@@ -369,6 +372,7 @@ fn eval_poly(coeffs: &[f64], x: f64) -> f64 {
         .sum()
 }
 
+#[allow(clippy::needless_range_loop)]
 fn solve(a: &mut [Vec<f64>], b: &mut [f64]) -> Option<Vec<f64>> {
     let n = b.len();
     for col in 0..n {

--- a/crates/geolibre-tools/src/warp_raster.rs
+++ b/crates/geolibre-tools/src/warp_raster.rs
@@ -334,6 +334,7 @@ fn eval(coeffs: &[f64], x: f64, y: f64, order: Order) -> f64 {
 }
 
 /// Gaussian elimination with partial pivoting; solves `a x = b` in place.
+#[allow(clippy::needless_range_loop)]
 fn solve(a: &mut [Vec<f64>], b: &mut [f64]) -> Option<Vec<f64>> {
     let n = b.len();
     for col in 0..n {


### PR DESCRIPTION
Silences clippy warnings in the round-4 tools (unused test import, needless_range_loop on numeric matrix/smoothing loops, and NaN-guarding negated comparisons rewritten explicitly). No behavior change; all 402 tests pass and the tools crate is clippy-clean apart from pre-existing warnings in older files.