### PR TITLE
fix(tools): restore kamadak-exif dependency for geotagged_photos_to_points

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,6 +959,7 @@ dependencies = [
  "geo",
  "geolibre-pmtiles",
  "h3o",
+ "kamadak-exif",
  "parquet",
  "png 0.17.16",
  "serde_json",
@@ -1750,6 +1751,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kamadak-exif"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1130d80c7374efad55a117d715a3af9368f0fa7a2c54573afc15a188cd984837"
+dependencies = [
+ "mutate_once",
+]
+
+[[package]]
 name = "kdtree"
 version = "0.8.0"
 dependencies = [
@@ -1891,6 +1901,12 @@ dependencies = [
  "num-traits",
  "pxfm",
 ]
+
+[[package]]
+name = "mutate_once"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "nalgebra"

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -50,3 +50,7 @@ h3o = { version = "0.10.0", features = ["geo"] }
 # minor `geo` uses internally so the `geo::Polygon` types unify (no duplicate
 # geo crate in the graph). Pure Rust, compiles to the wasm targets.
 geo = { version = "0.33", default-features = false }
+# Pure-Rust EXIF/TIFF-IFD metadata parser (no C deps, no image decoding),
+# used by geotagged_photos_to_points to read GPS + datetime + camera tags from
+# photo headers. WASM-clean. Crate name `kamadak-exif`, imported as `exif`.
+exif = { package = "kamadak-exif", version = "0.6.1" }


### PR DESCRIPTION
The `exif = { package = "kamadak-exif", ... }` dependency line was inadvertently dropped from `crates/geolibre-tools/Cargo.toml` during the round-5 batch merge, leaving `geotagged_photos_to_points` (PR #233) unable to compile on `main`. This restores the dependency and the corresponding `Cargo.lock` entries. `cargo test -p geolibre-tools` = 532 passing.