### PR TITLE
fix(tools): close disperse_markers schema arm (unbreak build)

### DIFF
--- a/crates/geolibre-tools/src/lib.rs
+++ b/crates/geolibre-tools/src/lib.rs
@@ -1448,6 +1448,7 @@ pub fn geolibre_param_schemas(tool_id: &str) -> Option<BTreeMap<String, ToolPara
                 ToolParamSchema::enum_values(&["expanded", "ring", "cross", "square"]),
             ),
             ("seed", int()),
+        ]),
         "zonal_histogram" => schemas(&[
             ("zones", raster_in()),
             ("value", raster_in()),


### PR DESCRIPTION
The #259 squash-merge landed a merge artifact that dropped the closing `]),` of the `disperse_markers` arm in `geolibre_param_schemas`, causing a `mismatched closing delimiter` build error on `main`. This one-line fix restores it. `cargo build` + full `cargo test -p geolibre-tools` (555 passed) green.