### PR TITLE
chore(release): bump version to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "0.11.0"
+version = "1.0.0"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -945,14 +945,14 @@ dependencies = [
 
 [[package]]
 name = "geolibre-pmtiles"
-version = "0.11.0"
+version = "1.0.0"
 dependencies = [
  "flate2",
 ]
 
 [[package]]
 name = "geolibre-tools"
-version = "0.11.0"
+version = "1.0.0"
 dependencies = [
  "flate2",
  "freestiler-core",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-wasm"
-version = "0.11.0"
+version = "1.0.0"
 dependencies = [
  "console_error_panic_hook",
  "geolibre-pmtiles",

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "0.11.0"
+version = "1.0.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-pmtiles/Cargo.toml
+++ b/crates/geolibre-pmtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-pmtiles"
-version = "0.11.0"
+version = "1.0.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "0.11.0"
+version = "1.0.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "0.11.0"
+version = "1.0.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "0.11.0",
+  "version": "1.0.0",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolibre-wasm"
-version = "0.11.0"
+version = "1.0.0"
 description = "Run the GeoLibre / whitebox_next_gen geospatial tool suite (WASM/WASI) from Python."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/geolibre_wasm/__init__.py
+++ b/python/src/geolibre_wasm/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "runtime_path",
 ]
 
-__version__ = "0.11.0"
+__version__ = "1.0.0"


### PR DESCRIPTION
First **major release** — v1.0.0.

Bumps all crate/npm/Python versions 0.11.0 → 1.0.0 (the last release tag `v0.11.0` sits ~124 commits back at #48, so this release bundles the entire ArcGIS-inspired geoprocessing suite added since — rounds 1–7, ~70 GeoLibre-authored tools, now **143 registered tools** alongside the bundled whitebox-wasm suite).

Once merged, pushing the `v1.0.0` tag triggers `release.yml` (WASM build, npm + PyPI Trusted Publishing, GitHub release with auto-generated notes).

No code changes — version strings + Cargo.lock only; `cargo check --workspace` is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package version to **1.0.0** across the CLI, tools, WebAssembly, npm, and Python distributions.
  * Exposed consistent version information across supported package formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->