### PR TITLE
chore(release): bump version to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -1016,14 +1016,14 @@ dependencies = [
 
 [[package]]
 name = "geolibre-pmtiles"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "flate2",
 ]
 
 [[package]]
 name = "geolibre-tools"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "calamine",
  "flate2",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-wasm"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "console_error_panic_hook",
  "geolibre-pmtiles",

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "1.0.0"
+version = "1.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-pmtiles/Cargo.toml
+++ b/crates/geolibre-pmtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-pmtiles"
-version = "1.0.0"
+version = "1.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "1.0.0"
+version = "1.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "1.0.0"
+version = "1.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolibre-wasm"
-version = "1.0.0"
+version = "1.1.0"
 description = "Run the GeoLibre / whitebox_next_gen geospatial tool suite (WASM/WASI) from Python."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/geolibre_wasm/__init__.py
+++ b/python/src/geolibre_wasm/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "runtime_path",
 ]
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"


### PR DESCRIPTION
## Release 1.1.0

Minor release bumping all crate/npm/python package versions `1.0.0 → 1.1.0`.

### New tools since 1.0.0 (round-10 ArcGIS-inspired batch, registry 195 → 201)

- `calculate_grid_convergence_angle` — per-feature grid-vs-true north angle (ArcGIS Calculate Grid Convergence Angle) — #403
- `enforce_river_monotonicity` — force DEM elevations to decrease downstream along river lines (ArcGIS Enforce River Monotonicity) — #404
- `spatial_eigenvector_filtering` — Moran eigenvector spatial filters / MESF (ArcGIS Decompose Spatial Structure) — #405
- `compare_spatial_weights` — rank spatial-weights conceptualizations by clustering strength (ArcGIS Compare Neighborhood Conceptualizations) — #406
- `diffusion_interpolation_with_barriers` — heat-equation interpolation around no-flux barriers (ArcGIS Diffusion Interpolation With Barriers) — #407
- `classification_accuracy_assessment` — confusion matrix + kappa from a classified raster vs reference points (ArcGIS Compute Confusion Matrix) — #408

### Notes

- Version bump only; no code changes in this PR. All 1060 `geolibre-tools` unit tests pass on `main`.
- Merging this PR and pushing the `v1.1.0` tag triggers the release workflow (WASM build + npm Trusted Publishing + GitHub release).
