### PR TITLE
chore(release): bump version to 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -1016,14 +1016,14 @@ dependencies = [
 
 [[package]]
 name = "geolibre-pmtiles"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "flate2",
 ]
 
 [[package]]
 name = "geolibre-tools"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "calamine",
  "flate2",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-wasm"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "console_error_panic_hook",
  "geolibre-pmtiles",

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "1.1.0"
+version = "1.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-pmtiles/Cargo.toml
+++ b/crates/geolibre-pmtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-pmtiles"
-version = "1.1.0"
+version = "1.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "1.1.0"
+version = "1.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "1.1.0"
+version = "1.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolibre-wasm"
-version = "1.1.0"
+version = "1.2.0"
 description = "Run the GeoLibre / whitebox_next_gen geospatial tool suite (WASM/WASI) from Python."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/geolibre_wasm/__init__.py
+++ b/python/src/geolibre_wasm/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "runtime_path",
 ]
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"


### PR DESCRIPTION
Bumps the workspace, npm package, and Python package to **1.2.0** ahead of the `v1.2.0` tag.

Version sites updated: the four workspace crates + `Cargo.lock`, `npm/package.json`, `python/pyproject.toml`, and `python/src/geolibre_wasm/__init__.py`.

## New tools since v1.1.0

- **ArcGIS round-13 batch** (#442) — polygon volume, hot-spot comparison, proximity grouping, planarize, split raster, surface parameters, rescale, transit frequency
- **ArcGIS round-12 batch** (#433) — zonal geometry/fill, polygon main angle, band collection stats, line statistics, optimized hot-spot/outlier analysis
- `las_height_metrics` (#424) — canopy height-metric raster from lidar
- `calculate_distance_band` (#419) — min/avg/max distance for N neighbors
- `gaussian_geostatistical_simulations` (#425) — N conditional realizations via sequential Gaussian simulation
- `regularize_adjacent_building_footprint` (#423) — group-consistent footprint regularization
- `find_meeting_locations` (#422) — multi-track spatiotemporal gatherings
- `optics_clustering` (#421) — multi-scale OPTICS density clustering
- `non_maximum_suppression` (#420) — IoU dedup of detections by confidence
- `cell_statistics` (#418) — per-pixel statistic across a raster stack

## Build

- Dropped the vendored `kdtree` patch in favour of the published `kdtree` 0.8.1 (#443)

Once merged, tagging `v1.2.0` on main triggers `release.yml`, which builds both WASM artifacts and publishes to npm and PyPI via Trusted Publishing, then attaches the release assets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated all distributed packages and components to version **1.2.0**.
  * Aligned version information across CLI, WebAssembly, Python, npm, and supporting tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->