### PR TITLE
fix(deps): bump whitebox-wasm so Raster Calculator equality works

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3590,7 +3590,7 @@ dependencies = [
 [[package]]
 name = "wbcore"
 version = "0.1.1"
-source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
+source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
 dependencies = [
  "serde",
  "serde_json",
@@ -3600,7 +3600,7 @@ dependencies = [
 [[package]]
 name = "wbgeotiff"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
+source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -3619,7 +3619,7 @@ dependencies = [
 [[package]]
 name = "wbhdf"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
+source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3630,7 +3630,7 @@ dependencies = [
 [[package]]
 name = "wblidar"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
+source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
 dependencies = [
  "rayon",
  "wbhdf",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "wbprojection"
 version = "0.3.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
+source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
 dependencies = [
  "thiserror 1.0.69",
  "wide 1.5.0",
@@ -3650,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "wbraster"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
+source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -3673,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "wbspatialstats"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
+source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
 dependencies = [
  "log",
  "nalgebra",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "wbtools_oss"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
+source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
 dependencies = [
  "bincode",
  "chrono",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "wbtopology"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
+source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
 dependencies = [
  "rayon",
  "robust",
@@ -3728,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "wbvector"
 version = "0.1.4"
-source = "git+https://github.com/opengeos/whitebox-wasm#c2b73194e5ced6f2dd8913dc77065b41b056980a"
+source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
 dependencies = [
  "bytes",
  "flatbuffers 24.12.23",


### PR DESCRIPTION
## Summary

Bumps the whitebox-wasm git dependency to 24173c5 to pull in opengeos/whitebox-wasm#12.

The expression normalizer there now promotes standalone integer literals to floats and rewrites SQL-style `=` to `==`. evalexpr never considers a `Float` equal to an `Int`, so equality tests like `"clusters" == 1` against Float raster cell values previously matched nothing (`!= 1` matched everything, and a lone `=` parsed as an assignment that turned the whole output into nodata). Fixes both the Raster Calculator and Conditional Evaluation tools.

## Testing

- `cargo test -p geolibre-cli -p geolibre-tools -p geolibre-pmtiles` passes locally with the bumped dependency.
- End-to-end coverage for `== 1`, `= 1`, and `!= 1` lives upstream in whitebox-wasm's test suite.

Ref opengeos/GeoLibre#1419 (GeoLibre consumes this via the next geolibre-wasm npm release).