### PR TITLE
feat(wasm): binary vector interop — deck.gl typed arrays, GeoArrow IPC, in-browser GeoParquet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           node-version: 22
 
       - name: Host tests
-        run: cargo test -p geolibre-cli -p geolibre-tools -p geolibre-pmtiles
+        run: cargo test -p geolibre-cli -p geolibre-tools -p geolibre-pmtiles -p geolibre-wasm
 
       - name: Build both WASM artifacts (library + WASI runner)
         run: ./build.sh

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -71,6 +71,7 @@ jobs:
           ./build.sh
           mkdir -p site
           cp demo/index.html           site/index.html
+          cp demo/benchmark.html       site/benchmark.html
           cp npm/tools.mjs             site/tools.mjs
           cp npm/geolibre-cli.wasm     site/geolibre-cli.wasm
           cp npm/geolibre_wasm.js      site/geolibre_wasm.js
@@ -78,7 +79,7 @@ jobs:
           cp examples/sample.tif       site/sample.tif
           # cache-bust the glue + wasm together so returning visitors never mix
           # an old cached loader with a freshly built module
-          sed -i "s/__BUILD__/${GITHUB_SHA}/g" site/index.html
+          sed -i "s/__BUILD__/${GITHUB_SHA}/g" site/index.html site/benchmark.html
 
       - uses: actions/configure-pages@v6
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,9 +1049,16 @@ dependencies = [
 name = "geolibre-wasm"
 version = "1.2.0"
 dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ipc",
+ "arrow-schema",
+ "bytes",
  "console_error_panic_hook",
  "geolibre-pmtiles",
  "getrandom 0.2.17",
+ "parquet",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-test",
  "wbgeotiff",

--- a/README.md
+++ b/README.md
@@ -413,6 +413,64 @@ console.log(r.width, r.height, r.bands, r.epsg);
 const band0 = r.read_band_f64(0);          // Float64Array
 ```
 
+### Vector data without JSON in the middle
+
+Reading a vector layer as GeoJSON hands JavaScript a *string*: the consumer pays
+for `JSON.parse` and then for re-encoding the parsed objects into the typed
+arrays a GPU actually wants. For a few hundred thousand features that dominates
+load time, so the same layer can also come back in binary form. All three paths
+share one reader, so any supported format (including GeoParquet, read straight
+from the buffer -- no server, no filesystem) works with any of them:
+
+```js
+import init, {
+  vector_to_geojson,   // string        -- portable, needs JSON.parse
+  vector_to_binary,    // typed arrays  -- deck.gl binary attributes
+  vector_to_arrow_ipc, // Uint8Array    -- GeoArrow record batch
+  vector_formats,
+} from "geolibre-wasm";
+
+await init();
+vector_formats(); // geojson,topojson,gml,gpx,kml,flatgeobuf,geopackage,kmz,geoparquet
+
+// deck.gl's binary layout: no string is ever produced.
+const b = vector_to_binary(parquetBytes, "geoparquet");
+const layer = new GeoJsonLayer({
+  data: {
+    points: {
+      type: "Point",
+      positions: { value: b.point_positions(), size: b.position_size },
+      featureIds: { value: b.point_feature_ids(), size: 1 },
+      globalFeatureIds: { value: b.point_global_feature_ids(), size: 1 },
+      properties: [],
+    },
+    lines: {}, polygons: {},
+  },
+});
+b.free(); // release the WASM-side buffers when done
+
+// Or one GeoArrow record batch, shared by the query engine and the renderer.
+const ipc = vector_to_arrow_ipc(fgbBytes, "flatgeobuf");
+const table = tableFromIPC(ipc);              // apache-arrow, zero-copy
+await conn.insertArrowFromIPCStream(ipc, { name: "roads" }); // DuckDB-WASM
+```
+
+Attributes come back columnar rather than as one JS object per feature:
+`schema_json` lists the fields, `numeric_column(i)` returns a `Float64Array`,
+and `text_column(i)` / `text_column_offsets(i)` return UTF-8 bytes with their
+split points. Geometry is delivered as `positions` plus the index arrays
+deck.gl expects (`line_path_indices()`, `polygon_indices()`,
+`polygon_primitive_polygon_indices()`), one set per geometry class.
+
+Both binary paths are cargo features of `geolibre-wasm`, on by default:
+`arrow` (Arrow IPC) and `geoparquet` (reading `.parquet` from bytes). Together
+they take the browser artifact from ~4.5 MB to ~6.4 MB (1.2 -> 1.9 MB
+gzipped); building with `--no-default-features` returns it to the smaller size
+and leaves `vector_to_binary` available.
+
+[`demo/benchmark.html`](demo/benchmark.html) times all three paths against each
+other on the same source bytes.
+
 Tool runner (the `./tools` export) -- the whitebox + GeoLibre tool suite:
 
 ```js

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -25,6 +25,29 @@ wbspatialstats = { git = "https://github.com/opengeos/whitebox-wasm" }
 geolibre-pmtiles = { path = "../geolibre-pmtiles" }
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1"
+# GeoArrow output + the in-memory GeoParquet reader. All four arrow crates and
+# parquet already arrive transitively through wbvector's `geoparquet` feature;
+# naming them here just makes them callable. Versions must stay in lockstep
+# with that transitive copy or the arrow types will not unify.
+#
+# Reaching this code is what costs bundle size, not linking it: making both
+# readers callable takes the browser artifact from ~4.5 MB to ~6.4 MB (1.2 ->
+# 1.9 MB gzipped). Both are on by default and can be switched off individually
+# by a size-sensitive consumer — see [features] below.
+arrow-array = { version = "58.3", optional = true }
+arrow-buffer = { version = "58.3", optional = true }
+arrow-ipc = { version = "58.3", optional = true }
+arrow-schema = { version = "58.3", optional = true }
+parquet = { version = "58.3", optional = true }
+bytes = { version = "1", optional = true }
+serde_json = { version = "1", optional = true }
+
+[features]
+default = ["arrow", "geoparquet"]
+# vector_to_arrow_ipc: GeoArrow-encoded Arrow IPC output.
+arrow = ["dep:arrow-array", "dep:arrow-buffer", "dep:arrow-ipc", "dep:arrow-schema"]
+# Reading .parquet from a byte buffer in the browser.
+geoparquet = ["dep:parquet", "dep:bytes", "dep:serde_json"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/geolibre-wasm/src/arrow_ipc.rs
+++ b/crates/geolibre-wasm/src/arrow_ipc.rs
@@ -1,0 +1,642 @@
+//! Vector data as a GeoArrow-encoded Arrow IPC stream.
+//!
+//! Where [`crate::binary`] targets deck.gl's own attribute layout, this targets
+//! the wider Arrow ecosystem: the bytes returned here go straight into
+//! `apache-arrow`'s `tableFromIPC` (zero-copy), into DuckDB-WASM via
+//! `insertArrowFromIPCStream`, or into `@geoarrow/deck.gl-layers`. No GeoJSON
+//! string, no `JSON.parse`, and one representation shared by the query engine
+//! and the renderer.
+//!
+//! Geometry uses GeoArrow's native (interleaved-coordinate) encoding when every
+//! feature in the layer shares one geometry type, which is the case for
+//! essentially all real layers, and falls back to `geoarrow.wkb` for mixed
+//! layers. Attributes become one Arrow column per field.
+
+use std::sync::Arc;
+
+use arrow_array::{
+    Array, ArrayRef, BinaryArray, BooleanArray, FixedSizeListArray, Float64Array, Int64Array,
+    ListArray, RecordBatch, StringArray,
+};
+use arrow_buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
+use arrow_ipc::writer::StreamWriter;
+use arrow_schema::{DataType, Field, Schema};
+use wasm_bindgen::prelude::*;
+use wbvector::feature::{FieldType, FieldValue, Layer};
+use wbvector::geometry::{Coord, Geometry, Ring};
+
+const EXT_NAME: &str = "ARROW:extension:name";
+const EXT_META: &str = "ARROW:extension:metadata";
+
+/// The GeoArrow encoding chosen for a layer.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Encoding {
+    Point,
+    LineString,
+    Polygon,
+    MultiPoint,
+    MultiLineString,
+    MultiPolygon,
+    /// Mixed or collection geometries: serialized as WKB.
+    Wkb,
+}
+
+impl Encoding {
+    fn extension_name(self) -> &'static str {
+        match self {
+            Self::Point => "geoarrow.point",
+            Self::LineString => "geoarrow.linestring",
+            Self::Polygon => "geoarrow.polygon",
+            Self::MultiPoint => "geoarrow.multipoint",
+            Self::MultiLineString => "geoarrow.multilinestring",
+            Self::MultiPolygon => "geoarrow.multipolygon",
+            Self::Wkb => "geoarrow.wkb",
+        }
+    }
+}
+
+/// Pick the encoding: the shared native type when every geometry agrees, WKB
+/// otherwise. A layer with no geometry at all is treated as WKB (all null).
+fn choose_encoding(layer: &Layer) -> Encoding {
+    let mut chosen: Option<Encoding> = None;
+    for geom in layer.features.iter().filter_map(|f| f.geometry.as_ref()) {
+        let e = match geom {
+            Geometry::Point(_) => Encoding::Point,
+            Geometry::LineString(_) => Encoding::LineString,
+            Geometry::Polygon { .. } => Encoding::Polygon,
+            Geometry::MultiPoint(_) => Encoding::MultiPoint,
+            Geometry::MultiLineString(_) => Encoding::MultiLineString,
+            Geometry::MultiPolygon(_) => Encoding::MultiPolygon,
+            Geometry::GeometryCollection(_) => return Encoding::Wkb,
+        };
+        match chosen {
+            None => chosen = Some(e),
+            Some(prev) if prev == e => {}
+            Some(_) => return Encoding::Wkb,
+        }
+    }
+    chosen.unwrap_or(Encoding::Wkb)
+}
+
+/// True if any coordinate carries Z, in which case every coordinate is written
+/// as XYZ (missing Z filled with 0) so the fixed-size list stays uniform.
+fn coord_dims(layer: &Layer) -> i32 {
+    fn ring_z(r: &Ring) -> bool {
+        r.coords().iter().any(|c| c.z.is_some())
+    }
+    fn geom_z(g: &Geometry) -> bool {
+        match g {
+            Geometry::Point(c) => c.z.is_some(),
+            Geometry::LineString(cs) | Geometry::MultiPoint(cs) => cs.iter().any(|c| c.z.is_some()),
+            Geometry::MultiLineString(ls) => ls.iter().flatten().any(|c| c.z.is_some()),
+            Geometry::Polygon {
+                exterior,
+                interiors,
+            } => ring_z(exterior) || interiors.iter().any(ring_z),
+            Geometry::MultiPolygon(ps) => ps.iter().any(|(e, i)| ring_z(e) || i.iter().any(ring_z)),
+            Geometry::GeometryCollection(gs) => gs.iter().any(geom_z),
+        }
+    }
+    let has_z = layer
+        .features
+        .iter()
+        .filter_map(|f| f.geometry.as_ref())
+        .any(geom_z);
+    if has_z {
+        3
+    } else {
+        2
+    }
+}
+
+/// Growing interleaved coordinate buffer.
+struct Coords {
+    values: Vec<f64>,
+    dims: i32,
+}
+
+impl Coords {
+    fn new(dims: i32) -> Self {
+        Self {
+            values: Vec::new(),
+            dims,
+        }
+    }
+    fn len(&self) -> i32 {
+        (self.values.len() / self.dims as usize) as i32
+    }
+    fn push(&mut self, c: &Coord) {
+        self.values.push(c.x);
+        self.values.push(c.y);
+        if self.dims == 3 {
+            self.values.push(c.z.unwrap_or(0.0));
+        }
+    }
+    /// Push a ring, closing it when the source stores it open.
+    fn push_ring(&mut self, r: &Ring) {
+        let coords = r.coords();
+        if coords.is_empty() {
+            return;
+        }
+        for c in coords {
+            self.push(c);
+        }
+        let (first, last) = (&coords[0], &coords[coords.len() - 1]);
+        if first.x != last.x || first.y != last.y {
+            self.push(first);
+        }
+    }
+    /// Finish as a `FixedSizeList<Float64>[dims]` with GeoArrow's field naming.
+    fn finish(self) -> FixedSizeListArray {
+        self.finish_with_nulls(None)
+    }
+
+    fn finish_with_nulls(self, nulls: Option<NullBuffer>) -> FixedSizeListArray {
+        let name = if self.dims == 3 { "xyz" } else { "xy" };
+        let field = Arc::new(Field::new(name, DataType::Float64, false));
+        FixedSizeListArray::new(
+            field,
+            self.dims,
+            Arc::new(Float64Array::from(self.values)),
+            nulls,
+        )
+    }
+}
+
+fn list_of(
+    name: &str,
+    values: ArrayRef,
+    offsets: Vec<i32>,
+    nulls: Option<NullBuffer>,
+) -> ListArray {
+    let field = Arc::new(Field::new(name, values.data_type().clone(), false));
+    ListArray::new(
+        field,
+        OffsetBuffer::new(ScalarBuffer::from(offsets)),
+        values,
+        nulls,
+    )
+}
+
+/// Validity for the geometry column: null wherever a feature has no geometry.
+fn geometry_nulls(layer: &Layer) -> Option<NullBuffer> {
+    let has_null = layer.features.iter().any(|f| f.geometry.is_none());
+    has_null.then(|| NullBuffer::from_iter(layer.features.iter().map(|f| f.geometry.is_some())))
+}
+
+/// Build the geometry column for `encoding`.
+///
+/// Every native branch walks the features once, appending coordinates and
+/// recording the offsets that delimit each nesting level.
+fn build_geometry(layer: &Layer, encoding: Encoding, dims: i32) -> Result<ArrayRef, String> {
+    let nulls = geometry_nulls(layer);
+    let geoms = || layer.features.iter().map(|f| f.geometry.as_ref());
+
+    Ok(match encoding {
+        Encoding::Point => {
+            let mut coords = Coords::new(dims);
+            for g in geoms() {
+                match g {
+                    Some(Geometry::Point(c)) => coords.push(c),
+                    // A null geometry still needs a slot in the fixed-size list.
+                    _ => coords.push(&Coord::xy(f64::NAN, f64::NAN)),
+                }
+            }
+            Arc::new(coords.finish_with_nulls(nulls))
+        }
+        Encoding::LineString | Encoding::MultiPoint => {
+            let vertex_name = if encoding == Encoding::MultiPoint {
+                "points"
+            } else {
+                "vertices"
+            };
+            let mut coords = Coords::new(dims);
+            let mut offsets = vec![0i32];
+            for g in geoms() {
+                match g {
+                    Some(Geometry::LineString(cs)) | Some(Geometry::MultiPoint(cs)) => {
+                        for c in cs {
+                            coords.push(c);
+                        }
+                    }
+                    _ => {}
+                }
+                offsets.push(coords.len());
+            }
+            Arc::new(list_of(
+                vertex_name,
+                Arc::new(coords.finish()),
+                offsets,
+                nulls,
+            ))
+        }
+        Encoding::Polygon | Encoding::MultiLineString => {
+            let (outer_name, inner_name) = if encoding == Encoding::Polygon {
+                ("rings", "vertices")
+            } else {
+                ("linestrings", "vertices")
+            };
+            let mut coords = Coords::new(dims);
+            let mut part_offsets = vec![0i32];
+            let mut feat_offsets = vec![0i32];
+            for g in geoms() {
+                match g {
+                    Some(Geometry::Polygon {
+                        exterior,
+                        interiors,
+                    }) => {
+                        coords.push_ring(exterior);
+                        part_offsets.push(coords.len());
+                        for hole in interiors {
+                            coords.push_ring(hole);
+                            part_offsets.push(coords.len());
+                        }
+                    }
+                    Some(Geometry::MultiLineString(paths)) => {
+                        for cs in paths {
+                            for c in cs {
+                                coords.push(c);
+                            }
+                            part_offsets.push(coords.len());
+                        }
+                    }
+                    _ => {}
+                }
+                feat_offsets.push((part_offsets.len() - 1) as i32);
+            }
+            let inner = list_of(inner_name, Arc::new(coords.finish()), part_offsets, None);
+            Arc::new(list_of(outer_name, Arc::new(inner), feat_offsets, nulls))
+        }
+        Encoding::MultiPolygon => {
+            let mut coords = Coords::new(dims);
+            let mut ring_offsets = vec![0i32];
+            let mut poly_offsets = vec![0i32];
+            let mut feat_offsets = vec![0i32];
+            for g in geoms() {
+                if let Some(Geometry::MultiPolygon(parts)) = g {
+                    for (exterior, interiors) in parts {
+                        coords.push_ring(exterior);
+                        ring_offsets.push(coords.len());
+                        for hole in interiors {
+                            coords.push_ring(hole);
+                            ring_offsets.push(coords.len());
+                        }
+                        poly_offsets.push((ring_offsets.len() - 1) as i32);
+                    }
+                }
+                feat_offsets.push((poly_offsets.len() - 1) as i32);
+            }
+            let rings = list_of("vertices", Arc::new(coords.finish()), ring_offsets, None);
+            let polys = list_of("rings", Arc::new(rings), poly_offsets, None);
+            Arc::new(list_of("polygons", Arc::new(polys), feat_offsets, nulls))
+        }
+        Encoding::Wkb => {
+            let wkb: Vec<Option<Vec<u8>>> = geoms().map(|g| g.map(|g| g.to_wkb())).collect();
+            let refs: Vec<Option<&[u8]>> = wkb.iter().map(|b| b.as_deref()).collect();
+            Arc::new(BinaryArray::from_opt_vec(refs))
+        }
+    })
+}
+
+/// GeoArrow extension metadata for the geometry field: the layer's CRS, in the
+/// two shapes the spec allows us to state confidently.
+fn extension_metadata(layer: &Layer) -> String {
+    if let Some(epsg) = layer.crs_epsg() {
+        return format!("{{\"crs\":\"EPSG:{epsg}\",\"crs_type\":\"authority_code\"}}");
+    }
+    match layer.crs_wkt() {
+        // The WKT flavour is unknown, so pass it through without a crs_type
+        // claim rather than mislabelling it.
+        Some(wkt) => format!("{{\"crs\":{}}}", json_string(wkt)),
+        None => "{}".to_string(),
+    }
+}
+
+/// Minimal JSON string escaping — enough for CRS WKT, which is ASCII with
+/// quotes and the occasional backslash.
+fn json_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Build one Arrow column from attribute field `index`.
+fn build_attribute(layer: &Layer, index: usize, field_type: FieldType) -> ArrayRef {
+    let values = || layer.features.iter().map(move |f| f.get_by_index(index));
+    match field_type {
+        FieldType::Integer => Arc::new(Int64Array::from_iter(
+            values().map(|v| v.and_then(FieldValue::as_i64)),
+        )) as ArrayRef,
+        FieldType::Float => Arc::new(Float64Array::from_iter(
+            values().map(|v| v.and_then(FieldValue::as_f64)),
+        )),
+        FieldType::Boolean => Arc::new(BooleanArray::from_iter(
+            values().map(|v| v.and_then(FieldValue::as_bool)),
+        )),
+        FieldType::Blob => {
+            let owned: Vec<Option<Vec<u8>>> = values()
+                .map(|v| v.and_then(FieldValue::as_blob).map(|b| b.to_vec()))
+                .collect();
+            let refs: Vec<Option<&[u8]>> = owned.iter().map(|b| b.as_deref()).collect();
+            Arc::new(BinaryArray::from_opt_vec(refs))
+        }
+        // Text, Date, DateTime and Json all land in Arrow as UTF-8. Dates keep
+        // their ISO-8601 text rather than being reinterpreted as a temporal
+        // type, which would need a parse that can fail on real-world data.
+        _ => Arc::new(StringArray::from_iter(values().map(|v| match v {
+            Some(FieldValue::Text(s))
+            | Some(FieldValue::Date(s))
+            | Some(FieldValue::DateTime(s)) => Some(s.clone()),
+            Some(FieldValue::Null) | None => None,
+            Some(other) => Some(crate::binary::field_text(other)),
+        }))),
+    }
+}
+
+/// Serialize a layer as a GeoArrow-encoded Arrow IPC stream.
+pub fn to_ipc(layer: &Layer) -> Result<Vec<u8>, String> {
+    let encoding = choose_encoding(layer);
+    let dims = coord_dims(layer);
+    let geometry = build_geometry(layer, encoding, dims)?;
+
+    let mut fields: Vec<Field> = Vec::with_capacity(layer.schema.len() + 1);
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(layer.schema.len() + 1);
+
+    for (i, def) in layer.schema.fields().iter().enumerate() {
+        let col = build_attribute(layer, i, def.field_type);
+        fields.push(Field::new(def.name.clone(), col.data_type().clone(), true));
+        columns.push(col);
+    }
+
+    let geom_field = Field::new("geometry", geometry.data_type().clone(), true).with_metadata(
+        [
+            (EXT_NAME.to_string(), encoding.extension_name().to_string()),
+            (EXT_META.to_string(), extension_metadata(layer)),
+        ]
+        .into_iter()
+        .collect(),
+    );
+    fields.push(geom_field);
+    columns.push(geometry);
+
+    let schema = Arc::new(
+        Schema::new(fields).with_metadata(
+            [("geolibre:layer".to_string(), layer.name.clone())]
+                .into_iter()
+                .collect(),
+        ),
+    );
+    let batch = RecordBatch::try_new(schema.clone(), columns)
+        .map_err(|e| format!("failed building record batch: {e}"))?;
+
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut writer = StreamWriter::try_new(&mut buf, &schema)
+            .map_err(|e| format!("failed opening IPC stream: {e}"))?;
+        writer
+            .write(&batch)
+            .map_err(|e| format!("failed writing record batch: {e}"))?;
+        writer
+            .finish()
+            .map_err(|e| format!("failed finishing IPC stream: {e}"))?;
+    }
+    Ok(buf)
+}
+
+/// Read a vector dataset and return it as a GeoArrow-encoded Arrow IPC stream.
+///
+/// `format` accepts the same names as [`crate::vector::vector_formats`]. Feed
+/// the bytes to `tableFromIPC` (apache-arrow) or
+/// `insertArrowFromIPCStream` (DuckDB-WASM).
+#[wasm_bindgen]
+pub fn vector_to_arrow_ipc(data: &[u8], format: &str) -> Result<Vec<u8>, JsValue> {
+    let layer = crate::vector::read_layer(data, format)?;
+    to_ipc(&layer).map_err(|e| JsValue::from_str(&e))
+}
+
+/// Read a vector dataset, reproject it to `dst_epsg`, and return a GeoArrow
+/// Arrow IPC stream. `src_epsg` of `0` uses the layer's own CRS (falling back
+/// to EPSG:4326).
+#[wasm_bindgen]
+pub fn vector_to_arrow_ipc_reproject(
+    data: &[u8],
+    format: &str,
+    dst_epsg: u32,
+    src_epsg: u32,
+) -> Result<Vec<u8>, JsValue> {
+    let layer = crate::vector::read_layer(data, format)?;
+    let layer = crate::vector::reproject_layer(layer, dst_epsg, src_epsg)?;
+    to_ipc(&layer).map_err(|e| JsValue::from_str(&e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_ipc::reader::StreamReader;
+    use wbvector::feature::{FieldDef, FieldType};
+    use wbvector::geometry::GeometryType;
+
+    fn read_back(bytes: &[u8]) -> RecordBatch {
+        let mut reader = StreamReader::try_new(std::io::Cursor::new(bytes.to_vec()), None).unwrap();
+        reader.next().unwrap().unwrap()
+    }
+
+    fn ring(coords: &[(f64, f64)]) -> Ring {
+        Ring::new(coords.iter().map(|(x, y)| Coord::xy(*x, *y)).collect())
+    }
+
+    #[test]
+    fn points_round_trip_as_geoarrow_point() {
+        let mut layer = Layer::new("cities")
+            .with_geom_type(GeometryType::Point)
+            .with_crs_epsg(4326);
+        layer.add_field(FieldDef::new("name", FieldType::Text));
+        layer.add_field(FieldDef::new("pop", FieldType::Integer));
+        layer
+            .add_feature(
+                Some(Geometry::point(-0.1, 51.5)),
+                &[("name", "London".into()), ("pop", 9_000_000i64.into())],
+            )
+            .unwrap();
+        layer
+            .add_feature(
+                Some(Geometry::point(10.7, 59.9)),
+                &[("name", "Oslo".into()), ("pop", 700_000i64.into())],
+            )
+            .unwrap();
+
+        let batch = read_back(&to_ipc(&layer).unwrap());
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(batch.num_columns(), 3);
+
+        let geom_field = batch.schema().field(2).clone();
+        assert_eq!(geom_field.name(), "geometry");
+        assert_eq!(
+            geom_field.metadata().get(EXT_NAME).unwrap(),
+            "geoarrow.point"
+        );
+        assert!(geom_field
+            .metadata()
+            .get(EXT_META)
+            .unwrap()
+            .contains("EPSG:4326"));
+
+        let coords = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<FixedSizeListArray>()
+            .unwrap();
+        assert_eq!(coords.value_length(), 2);
+        let flat = coords
+            .values()
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert_eq!(flat.values(), &[-0.1, 51.5, 10.7, 59.9]);
+
+        let names = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(names.value(0), "London");
+        let pops = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(pops.value(1), 700_000);
+    }
+
+    #[test]
+    fn polygons_nest_rings_and_close_them() {
+        let mut layer = Layer::new("polys");
+        layer
+            .add_feature(
+                Some(Geometry::Polygon {
+                    // Open ring: the writer must close it.
+                    exterior: ring(&[(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0)]),
+                    interiors: vec![ring(&[(0.5, 0.5), (1.0, 0.5), (1.0, 1.0), (0.5, 0.5)])],
+                }),
+                &[],
+            )
+            .unwrap();
+
+        let batch = read_back(&to_ipc(&layer).unwrap());
+        assert_eq!(
+            batch.schema().field(0).metadata().get(EXT_NAME).unwrap(),
+            "geoarrow.polygon"
+        );
+        let polys = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap();
+        let rings = polys
+            .value(0)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap()
+            .clone();
+        assert_eq!(rings.len(), 2); // exterior + one hole
+        assert_eq!(rings.value(0).len(), 5); // closed
+        assert_eq!(rings.value(1).len(), 4); // already closed
+    }
+
+    #[test]
+    fn mixed_geometry_types_fall_back_to_wkb() {
+        let mut layer = Layer::new("mixed");
+        layer
+            .add_feature(Some(Geometry::point(0.0, 0.0)), &[])
+            .unwrap();
+        layer
+            .add_feature(
+                Some(Geometry::LineString(vec![
+                    Coord::xy(0.0, 0.0),
+                    Coord::xy(1.0, 1.0),
+                ])),
+                &[],
+            )
+            .unwrap();
+
+        assert_eq!(choose_encoding(&layer), Encoding::Wkb);
+        let batch = read_back(&to_ipc(&layer).unwrap());
+        assert_eq!(
+            batch.schema().field(0).metadata().get(EXT_NAME).unwrap(),
+            "geoarrow.wkb"
+        );
+        let wkb = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        // Both geometries survive the round trip through WKB.
+        assert!(matches!(
+            Geometry::from_wkb(wkb.value(0)).unwrap(),
+            Geometry::Point(_)
+        ));
+        assert!(matches!(
+            Geometry::from_wkb(wkb.value(1)).unwrap(),
+            Geometry::LineString(_)
+        ));
+    }
+
+    #[test]
+    fn missing_geometry_becomes_a_null_slot() {
+        let mut layer = Layer::new("sparse");
+        layer
+            .add_feature(Some(Geometry::point(1.0, 1.0)), &[])
+            .unwrap();
+        layer.add_feature(None, &[]).unwrap();
+
+        let batch = read_back(&to_ipc(&layer).unwrap());
+        let geom = batch.column(0);
+        assert!(!geom.is_null(0));
+        assert!(geom.is_null(1));
+    }
+
+    #[test]
+    fn z_coordinates_widen_the_fixed_size_list() {
+        let mut layer = Layer::new("3d");
+        layer
+            .add_feature(Some(Geometry::point_z(1.0, 2.0, 3.0)), &[])
+            .unwrap();
+        layer
+            .add_feature(Some(Geometry::point(4.0, 5.0)), &[])
+            .unwrap();
+
+        let batch = read_back(&to_ipc(&layer).unwrap());
+        let coords = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<FixedSizeListArray>()
+            .unwrap();
+        assert_eq!(coords.value_length(), 3);
+        let flat = coords
+            .values()
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert_eq!(flat.values(), &[1.0, 2.0, 3.0, 4.0, 5.0, 0.0]);
+    }
+
+    #[test]
+    fn wkt_crs_is_passed_through_without_a_type_claim() {
+        let layer = Layer::new("wkt").with_crs_wkt(r#"GEOGCS["WGS 84","quoted"]"#);
+        let meta = extension_metadata(&layer);
+        assert!(meta.contains("\\\"quoted\\\""), "unescaped WKT: {meta}");
+        assert!(!meta.contains("crs_type"));
+    }
+}

--- a/crates/geolibre-wasm/src/binary.rs
+++ b/crates/geolibre-wasm/src/binary.rs
@@ -1,0 +1,688 @@
+//! Vector data as flat typed arrays, in deck.gl's binary-attribute layout.
+//!
+//! [`crate::vector::vector_to_geojson`] hands JavaScript a GeoJSON *string*.
+//! The consumer then pays for `JSON.parse` and for re-encoding the parsed
+//! objects into the typed arrays a GPU actually wants — twice the work, on a
+//! representation that is roughly an order of magnitude larger than the
+//! coordinates it carries. For a few hundred thousand features that dominates
+//! load time.
+//!
+//! [`vector_to_binary`] skips both steps: geometry comes back as
+//! `Float64Array` positions plus `Uint32Array` index arrays laid out exactly as
+//! `@deck.gl/layers`' binary `GeoJsonLayer` expects, and attributes come back
+//! as columnar arrays (one per field, one entry per feature) instead of one JS
+//! object per feature.
+//!
+//! Layout, per geometry class (`points` / `lines` / `polygons`):
+//! - `positions` — `[x, y, (z), ...]`, `position_size()` values per vertex
+//! - `feature_ids` — per vertex, index into that class's feature list
+//! - `global_feature_ids` — per vertex, index into the whole layer
+//! - `feature_index` — per class feature, its index in the whole layer
+//! - lines: `path_indices` — vertex offsets delimiting each path, `n_paths + 1`
+//!   entries, ending at the total vertex count
+//! - polygons: `primitive_polygon_indices` (ring offsets) and `polygon_indices`
+//!   (polygon offsets), same convention
+//!
+//! Rings are emitted closed (first vertex repeated last) so outlines draw
+//! correctly even when the source format stores them open.
+
+use wasm_bindgen::prelude::*;
+use wbvector::feature::{FieldType, FieldValue, Layer};
+use wbvector::geometry::{Coord, Geometry, Ring};
+
+/// One geometry class's buffers.
+#[derive(Default)]
+struct ClassBuf {
+    positions: Vec<f64>,
+    feature_ids: Vec<u32>,
+    global_feature_ids: Vec<u32>,
+    /// Class-local feature index -> index in the whole layer.
+    feature_index: Vec<u32>,
+    /// Vertex offsets delimiting paths (lines) or rings (polygons).
+    part_indices: Vec<u32>,
+    /// Vertex offsets delimiting whole polygons (polygons only).
+    polygon_indices: Vec<u32>,
+}
+
+impl ClassBuf {
+    /// Vertices written so far.
+    fn vertex_count(&self, size: usize) -> u32 {
+        (self.positions.len() / size) as u32
+    }
+
+    /// Claim a class-local id for the layer feature `global`.
+    fn claim(&mut self, global: u32) -> u32 {
+        self.feature_index.push(global);
+        (self.feature_index.len() - 1) as u32
+    }
+
+    fn push_coord(&mut self, c: &Coord, size: usize, local: u32, global: u32) {
+        self.positions.push(c.x);
+        self.positions.push(c.y);
+        if size == 3 {
+            self.positions.push(c.z.unwrap_or(0.0));
+        }
+        self.feature_ids.push(local);
+        self.global_feature_ids.push(global);
+    }
+
+    /// Append a ring, repeating the first vertex when the source leaves it open.
+    fn push_ring(&mut self, ring: &Ring, size: usize, local: u32, global: u32) {
+        let coords = ring.coords();
+        if coords.is_empty() {
+            return;
+        }
+        for c in coords {
+            self.push_coord(c, size, local, global);
+        }
+        let first = &coords[0];
+        let last = &coords[coords.len() - 1];
+        if first.x != last.x || first.y != last.y {
+            self.push_coord(first, size, local, global);
+        }
+    }
+}
+
+/// A layer's geometry and attributes as flat typed arrays.
+///
+/// Produced by [`vector_to_binary`]. Every accessor copies into a fresh
+/// JavaScript typed array, so read each one once and keep the reference.
+#[wasm_bindgen]
+pub struct VectorBinary {
+    feature_count: usize,
+    position_size: usize,
+    epsg: Option<u32>,
+    bounds: Option<[f64; 4]>,
+    points: ClassBuf,
+    lines: ClassBuf,
+    polygons: ClassBuf,
+    fields: Vec<(String, FieldType)>,
+    /// Per field, per feature. Parallel to `fields`.
+    columns: Vec<Vec<FieldValue>>,
+}
+
+#[wasm_bindgen]
+impl VectorBinary {
+    /// Number of features in the source layer.
+    #[wasm_bindgen(getter)]
+    pub fn feature_count(&self) -> usize {
+        self.feature_count
+    }
+
+    /// Values per vertex in every `positions` array: 2, or 3 when any geometry
+    /// carries a Z coordinate.
+    #[wasm_bindgen(getter)]
+    pub fn position_size(&self) -> usize {
+        self.position_size
+    }
+
+    /// EPSG code of the layer's CRS, if it declares one.
+    #[wasm_bindgen(getter)]
+    pub fn epsg(&self) -> Option<u32> {
+        self.epsg
+    }
+
+    /// Bounds as `[min_x, min_y, max_x, max_y]`, or an empty array when the
+    /// layer has no geometry.
+    #[wasm_bindgen(getter)]
+    pub fn bbox(&self) -> Vec<f64> {
+        self.bounds.map(|b| b.to_vec()).unwrap_or_default()
+    }
+
+    /// Attribute schema as JSON: `[{"name":...,"type":...}, ...]`. Field values
+    /// themselves come from [`Self::numeric_column`] / [`Self::text_column`].
+    #[wasm_bindgen(getter)]
+    pub fn schema_json(&self) -> String {
+        let fields: Vec<String> = self
+            .fields
+            .iter()
+            .map(|(n, t)| {
+                format!(
+                    "{{\"name\":\"{}\",\"type\":\"{}\"}}",
+                    n.replace('"', "'"),
+                    t.as_str()
+                )
+            })
+            .collect();
+        format!("[{}]", fields.join(","))
+    }
+
+    /// Number of attribute fields.
+    #[wasm_bindgen(getter)]
+    pub fn field_count(&self) -> usize {
+        self.fields.len()
+    }
+
+    // ── points ──────────────────────────────────────────────────────────────
+
+    /// Point positions, `position_size` values per vertex.
+    pub fn point_positions(&self) -> Vec<f64> {
+        self.points.positions.clone()
+    }
+    /// Per point vertex: index into the point feature list.
+    pub fn point_feature_ids(&self) -> Vec<u32> {
+        self.points.feature_ids.clone()
+    }
+    /// Per point vertex: index into the whole layer.
+    pub fn point_global_feature_ids(&self) -> Vec<u32> {
+        self.points.global_feature_ids.clone()
+    }
+    /// Per point feature: its index in the whole layer.
+    pub fn point_feature_index(&self) -> Vec<u32> {
+        self.points.feature_index.clone()
+    }
+
+    // ── lines ───────────────────────────────────────────────────────────────
+
+    /// Line positions, `position_size` values per vertex.
+    pub fn line_positions(&self) -> Vec<f64> {
+        self.lines.positions.clone()
+    }
+    /// Vertex offsets delimiting each path; ends at the total vertex count.
+    pub fn line_path_indices(&self) -> Vec<u32> {
+        terminated(&self.lines, self.position_size)
+    }
+    /// Per line vertex: index into the line feature list.
+    pub fn line_feature_ids(&self) -> Vec<u32> {
+        self.lines.feature_ids.clone()
+    }
+    /// Per line vertex: index into the whole layer.
+    pub fn line_global_feature_ids(&self) -> Vec<u32> {
+        self.lines.global_feature_ids.clone()
+    }
+    /// Per line feature: its index in the whole layer.
+    pub fn line_feature_index(&self) -> Vec<u32> {
+        self.lines.feature_index.clone()
+    }
+
+    // ── polygons ────────────────────────────────────────────────────────────
+
+    /// Polygon positions, `position_size` values per vertex.
+    pub fn polygon_positions(&self) -> Vec<f64> {
+        self.polygons.positions.clone()
+    }
+    /// Vertex offsets delimiting each ring (exterior and holes alike).
+    pub fn polygon_primitive_polygon_indices(&self) -> Vec<u32> {
+        terminated(&self.polygons, self.position_size)
+    }
+    /// Vertex offsets delimiting each whole polygon.
+    pub fn polygon_indices(&self) -> Vec<u32> {
+        let mut v = self.polygons.polygon_indices.clone();
+        if !v.is_empty() {
+            v.push(self.polygons.vertex_count(self.position_size));
+        }
+        v
+    }
+    /// Per polygon vertex: index into the polygon feature list.
+    pub fn polygon_feature_ids(&self) -> Vec<u32> {
+        self.polygons.feature_ids.clone()
+    }
+    /// Per polygon vertex: index into the whole layer.
+    pub fn polygon_global_feature_ids(&self) -> Vec<u32> {
+        self.polygons.global_feature_ids.clone()
+    }
+    /// Per polygon feature: its index in the whole layer.
+    pub fn polygon_feature_index(&self) -> Vec<u32> {
+        self.polygons.feature_index.clone()
+    }
+
+    // ── attributes ──────────────────────────────────────────────────────────
+
+    /// Field `index` as one `f64` per feature: integers and floats as-is,
+    /// booleans as 1/0, everything else (including nulls) as `NaN`.
+    pub fn numeric_column(&self, index: usize) -> Result<Vec<f64>, JsValue> {
+        self.numeric_column_impl(index)
+            .map_err(|e| JsValue::from_str(&e))
+    }
+
+    /// Field `index` as UTF-8 bytes for every feature, concatenated. Split it
+    /// with [`Self::text_column_offsets`]. Non-text values are stringified;
+    /// nulls are empty.
+    pub fn text_column(&self, index: usize) -> Result<Vec<u8>, JsValue> {
+        self.text_column_impl(index)
+            .map_err(|e| JsValue::from_str(&e))
+    }
+
+    /// Byte offsets into [`Self::text_column`], `feature_count + 1` entries.
+    pub fn text_column_offsets(&self, index: usize) -> Result<Vec<u32>, JsValue> {
+        self.text_column_offsets_impl(index)
+            .map_err(|e| JsValue::from_str(&e))
+    }
+}
+
+// Plain-Rust bodies, kept off the `#[wasm_bindgen]` impl block so they can be
+// unit-tested natively: constructing a `JsValue` panics off wasm32.
+impl VectorBinary {
+    fn numeric_column_impl(&self, index: usize) -> Result<Vec<f64>, String> {
+        let col = self.column(index)?;
+        Ok(col
+            .iter()
+            .map(|v| match v {
+                FieldValue::Integer(i) => *i as f64,
+                FieldValue::Float(f) => *f,
+                FieldValue::Boolean(b) => {
+                    if *b {
+                        1.0
+                    } else {
+                        0.0
+                    }
+                }
+                _ => f64::NAN,
+            })
+            .collect())
+    }
+
+    fn text_column_impl(&self, index: usize) -> Result<Vec<u8>, String> {
+        let col = self.column(index)?;
+        let mut out = Vec::new();
+        for v in col {
+            out.extend_from_slice(field_text(v).as_bytes());
+        }
+        Ok(out)
+    }
+
+    fn text_column_offsets_impl(&self, index: usize) -> Result<Vec<u32>, String> {
+        let col = self.column(index)?;
+        let mut out = Vec::with_capacity(col.len() + 1);
+        let mut at = 0u32;
+        out.push(at);
+        for v in col {
+            at += field_text(v).len() as u32;
+            out.push(at);
+        }
+        Ok(out)
+    }
+
+    fn column(&self, index: usize) -> Result<&Vec<FieldValue>, String> {
+        self.columns.get(index).ok_or_else(|| {
+            format!(
+                "field index {index} out of range (layer has {} fields)",
+                self.fields.len()
+            )
+        })
+    }
+}
+
+/// A part-offset array with its terminating total-vertex-count entry. Empty
+/// stays empty so consumers can test for "this class has no geometry".
+fn terminated(buf: &ClassBuf, size: usize) -> Vec<u32> {
+    let mut v = buf.part_indices.clone();
+    if !v.is_empty() {
+        v.push(buf.vertex_count(size));
+    }
+    v
+}
+
+/// Display form of an attribute value, shared with the Arrow encoder.
+pub(crate) fn field_text(v: &FieldValue) -> String {
+    match v {
+        FieldValue::Null => String::new(),
+        FieldValue::Text(s) | FieldValue::Date(s) | FieldValue::DateTime(s) => s.clone(),
+        FieldValue::Integer(i) => i.to_string(),
+        FieldValue::Float(f) => f.to_string(),
+        FieldValue::Boolean(b) => b.to_string(),
+        FieldValue::Blob(b) => format!("<{} bytes>", b.len()),
+    }
+}
+
+/// True if any coordinate in the layer carries a Z value.
+fn needs_z(layer: &Layer) -> bool {
+    fn geom_has_z(g: &Geometry) -> bool {
+        match g {
+            Geometry::Point(c) => c.z.is_some(),
+            Geometry::LineString(cs) | Geometry::MultiPoint(cs) => cs.iter().any(|c| c.z.is_some()),
+            Geometry::MultiLineString(ls) => ls.iter().flatten().any(|c| c.z.is_some()),
+            Geometry::Polygon {
+                exterior,
+                interiors,
+            } => ring_has_z(exterior) || interiors.iter().any(ring_has_z),
+            Geometry::MultiPolygon(ps) => ps
+                .iter()
+                .any(|(ext, ints)| ring_has_z(ext) || ints.iter().any(ring_has_z)),
+            Geometry::GeometryCollection(gs) => gs.iter().any(geom_has_z),
+        }
+    }
+    fn ring_has_z(r: &Ring) -> bool {
+        r.coords().iter().any(|c| c.z.is_some())
+    }
+    layer
+        .features
+        .iter()
+        .filter_map(|f| f.geometry.as_ref())
+        .any(geom_has_z)
+}
+
+/// Flatten one layer into the binary layout.
+pub fn build(layer: &Layer) -> VectorBinary {
+    let size = if needs_z(layer) { 3 } else { 2 };
+    let mut points = ClassBuf::default();
+    let mut lines = ClassBuf::default();
+    let mut polygons = ClassBuf::default();
+    // Class-local ids are claimed lazily, so a feature that contributes to two
+    // classes (a GeometryCollection) gets one id in each.
+    let mut bounds: Option<[f64; 4]> = None;
+
+    for (gi, feature) in layer.features.iter().enumerate() {
+        let Some(geom) = feature.geometry.as_ref() else {
+            continue;
+        };
+        let gi = gi as u32;
+        let mut ids = (None, None, None);
+        write_geometry(
+            geom,
+            size,
+            gi,
+            &mut ids,
+            &mut points,
+            &mut lines,
+            &mut polygons,
+        );
+    }
+
+    for chunk in points
+        .positions
+        .chunks_exact(size)
+        .chain(lines.positions.chunks_exact(size))
+        .chain(polygons.positions.chunks_exact(size))
+    {
+        let (x, y) = (chunk[0], chunk[1]);
+        bounds = Some(match bounds {
+            None => [x, y, x, y],
+            Some([a, b, c, d]) => [a.min(x), b.min(y), c.max(x), d.max(y)],
+        });
+    }
+
+    let fields: Vec<(String, FieldType)> = layer
+        .schema
+        .fields()
+        .iter()
+        .map(|f| (f.name.clone(), f.field_type))
+        .collect();
+    let columns: Vec<Vec<FieldValue>> = (0..fields.len())
+        .map(|i| {
+            layer
+                .features
+                .iter()
+                .map(|f| f.get_by_index(i).cloned().unwrap_or(FieldValue::Null))
+                .collect()
+        })
+        .collect();
+
+    VectorBinary {
+        feature_count: layer.features.len(),
+        position_size: size,
+        epsg: layer.crs_epsg(),
+        bounds,
+        points,
+        lines,
+        polygons,
+        fields,
+        columns,
+    }
+}
+
+/// Per-feature class-local ids, claimed on first use: `(point, line, polygon)`.
+type LocalIds = (Option<u32>, Option<u32>, Option<u32>);
+
+fn write_geometry(
+    geom: &Geometry,
+    size: usize,
+    global: u32,
+    ids: &mut LocalIds,
+    points: &mut ClassBuf,
+    lines: &mut ClassBuf,
+    polygons: &mut ClassBuf,
+) {
+    match geom {
+        Geometry::Point(c) => {
+            let local = *ids.0.get_or_insert_with(|| points.claim(global));
+            points.push_coord(c, size, local, global);
+        }
+        Geometry::MultiPoint(cs) => {
+            let local = *ids.0.get_or_insert_with(|| points.claim(global));
+            for c in cs {
+                points.push_coord(c, size, local, global);
+            }
+        }
+        Geometry::LineString(cs) => {
+            let local = *ids.1.get_or_insert_with(|| lines.claim(global));
+            write_path(cs, size, local, global, lines);
+        }
+        Geometry::MultiLineString(paths) => {
+            let local = *ids.1.get_or_insert_with(|| lines.claim(global));
+            for cs in paths {
+                write_path(cs, size, local, global, lines);
+            }
+        }
+        Geometry::Polygon {
+            exterior,
+            interiors,
+        } => {
+            let local = *ids.2.get_or_insert_with(|| polygons.claim(global));
+            write_polygon(exterior, interiors, size, local, global, polygons);
+        }
+        Geometry::MultiPolygon(parts) => {
+            let local = *ids.2.get_or_insert_with(|| polygons.claim(global));
+            for (exterior, interiors) in parts {
+                write_polygon(exterior, interiors, size, local, global, polygons);
+            }
+        }
+        Geometry::GeometryCollection(gs) => {
+            for g in gs {
+                write_geometry(g, size, global, ids, points, lines, polygons);
+            }
+        }
+    }
+}
+
+fn write_path(coords: &[Coord], size: usize, local: u32, global: u32, buf: &mut ClassBuf) {
+    if coords.is_empty() {
+        return;
+    }
+    buf.part_indices.push(buf.vertex_count(size));
+    for c in coords {
+        buf.push_coord(c, size, local, global);
+    }
+}
+
+fn write_polygon(
+    exterior: &Ring,
+    interiors: &[Ring],
+    size: usize,
+    local: u32,
+    global: u32,
+    buf: &mut ClassBuf,
+) {
+    if exterior.coords().is_empty() {
+        return;
+    }
+    buf.polygon_indices.push(buf.vertex_count(size));
+    buf.part_indices.push(buf.vertex_count(size));
+    buf.push_ring(exterior, size, local, global);
+    for hole in interiors {
+        if hole.coords().is_empty() {
+            continue;
+        }
+        buf.part_indices.push(buf.vertex_count(size));
+        buf.push_ring(hole, size, local, global);
+    }
+}
+
+/// Read a vector dataset and return its geometry and attributes as flat typed
+/// arrays — no GeoJSON string, no `JSON.parse`.
+///
+/// `format` accepts the same names as [`crate::vector::vector_formats`].
+#[wasm_bindgen]
+pub fn vector_to_binary(data: &[u8], format: &str) -> Result<VectorBinary, JsValue> {
+    Ok(build(&crate::vector::read_layer(data, format)?))
+}
+
+/// Read a vector dataset, reproject it to `dst_epsg`, and return flat typed
+/// arrays. `src_epsg` of `0` uses the layer's own CRS (falling back to
+/// EPSG:4326), matching [`crate::vector::vector_to_geojson_reproject`].
+#[wasm_bindgen]
+pub fn vector_to_binary_reproject(
+    data: &[u8],
+    format: &str,
+    dst_epsg: u32,
+    src_epsg: u32,
+) -> Result<VectorBinary, JsValue> {
+    let layer = crate::vector::read_layer(data, format)?;
+    Ok(build(&crate::vector::reproject_layer(
+        layer, dst_epsg, src_epsg,
+    )?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wbvector::feature::{FieldDef, FieldType};
+    use wbvector::geometry::GeometryType;
+
+    fn ring(coords: &[(f64, f64)]) -> Ring {
+        Ring::new(coords.iter().map(|(x, y)| Coord::xy(*x, *y)).collect())
+    }
+
+    #[test]
+    fn points_flatten_to_positions_and_ids() {
+        let mut layer = Layer::new("pts").with_geom_type(GeometryType::Point);
+        layer.add_field(FieldDef::new("pop", FieldType::Integer));
+        layer
+            .add_feature(Some(Geometry::point(1.0, 2.0)), &[("pop", 10i64.into())])
+            .unwrap();
+        layer
+            .add_feature(Some(Geometry::point(3.0, 4.0)), &[("pop", 20i64.into())])
+            .unwrap();
+
+        let b = build(&layer);
+        assert_eq!(b.position_size(), 2);
+        assert_eq!(b.point_positions(), vec![1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(b.point_feature_ids(), vec![0, 1]);
+        assert_eq!(b.point_global_feature_ids(), vec![0, 1]);
+        assert_eq!(b.point_feature_index(), vec![0, 1]);
+        assert_eq!(b.numeric_column(0).unwrap(), vec![10.0, 20.0]);
+        assert_eq!(b.bbox(), vec![1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn multi_line_paths_are_delimited_and_terminated() {
+        let mut layer = Layer::new("lines");
+        let geom = Geometry::MultiLineString(vec![
+            vec![Coord::xy(0.0, 0.0), Coord::xy(1.0, 1.0)],
+            vec![
+                Coord::xy(2.0, 2.0),
+                Coord::xy(3.0, 3.0),
+                Coord::xy(4.0, 4.0),
+            ],
+        ]);
+        layer.add_feature(Some(geom), &[]).unwrap();
+
+        let b = build(&layer);
+        // Two paths of 2 and 3 vertices: offsets 0, 2, terminated at 5.
+        assert_eq!(b.line_path_indices(), vec![0, 2, 5]);
+        assert_eq!(b.line_positions().len(), 10);
+        assert_eq!(b.line_feature_ids(), vec![0; 5]);
+    }
+
+    #[test]
+    fn polygon_rings_close_and_holes_get_their_own_offsets() {
+        let mut layer = Layer::new("polys");
+        // Deliberately open ring: the builder must close it.
+        let exterior = ring(&[(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0)]);
+        let hole = ring(&[(1.0, 1.0), (2.0, 1.0), (2.0, 2.0), (1.0, 2.0), (1.0, 1.0)]);
+        layer
+            .add_feature(
+                Some(Geometry::Polygon {
+                    exterior,
+                    interiors: vec![hole],
+                }),
+                &[],
+            )
+            .unwrap();
+
+        let b = build(&layer);
+        // Exterior closes to 5 vertices, hole is already closed at 5.
+        assert_eq!(b.polygon_primitive_polygon_indices(), vec![0, 5, 10]);
+        assert_eq!(b.polygon_indices(), vec![0, 10]);
+        let pos = b.polygon_positions();
+        assert_eq!(pos.len(), 20);
+        assert_eq!(&pos[0..2], &[0.0, 0.0]);
+        assert_eq!(&pos[8..10], &[0.0, 0.0]); // ring closed back to the start
+    }
+
+    #[test]
+    fn geometry_collection_feeds_every_class_with_its_own_local_id() {
+        let mut layer = Layer::new("mixed");
+        layer
+            .add_feature(Some(Geometry::point(9.0, 9.0)), &[])
+            .unwrap();
+        layer
+            .add_feature(
+                Some(Geometry::GeometryCollection(vec![
+                    Geometry::point(0.0, 0.0),
+                    Geometry::LineString(vec![Coord::xy(0.0, 0.0), Coord::xy(1.0, 0.0)]),
+                ])),
+                &[],
+            )
+            .unwrap();
+
+        let b = build(&layer);
+        assert_eq!(b.point_feature_index(), vec![0, 1]);
+        assert_eq!(b.point_feature_ids(), vec![0, 1]);
+        assert_eq!(b.line_feature_index(), vec![1]);
+        assert_eq!(b.line_feature_ids(), vec![0, 0]);
+        assert_eq!(b.line_path_indices(), vec![0, 2]);
+    }
+
+    #[test]
+    fn z_coordinates_widen_every_class_to_size_three() {
+        let mut layer = Layer::new("3d");
+        layer
+            .add_feature(Some(Geometry::point_z(1.0, 2.0, 3.0)), &[])
+            .unwrap();
+        layer
+            .add_feature(Some(Geometry::point(4.0, 5.0)), &[])
+            .unwrap();
+
+        let b = build(&layer);
+        assert_eq!(b.position_size(), 3);
+        assert_eq!(b.point_positions(), vec![1.0, 2.0, 3.0, 4.0, 5.0, 0.0]);
+    }
+
+    #[test]
+    fn text_columns_split_on_byte_offsets() {
+        let mut layer = Layer::new("named");
+        layer.add_field(FieldDef::new("name", FieldType::Text));
+        layer
+            .add_feature(
+                Some(Geometry::point(0.0, 0.0)),
+                &[("name", "Zürich".into())],
+            )
+            .unwrap();
+        layer
+            .add_feature(Some(Geometry::point(1.0, 1.0)), &[("name", "Oslo".into())])
+            .unwrap();
+
+        let b = build(&layer);
+        let bytes = b.text_column(0).unwrap();
+        let offsets = b.text_column_offsets(0).unwrap();
+        assert_eq!(offsets.len(), 3);
+        let first = std::str::from_utf8(&bytes[offsets[0] as usize..offsets[1] as usize]).unwrap();
+        let second = std::str::from_utf8(&bytes[offsets[1] as usize..offsets[2] as usize]).unwrap();
+        assert_eq!(first, "Zürich"); // multi-byte char: offsets are bytes, not chars
+        assert_eq!(second, "Oslo");
+        assert!(b.numeric_column_impl(1).is_err());
+    }
+
+    #[test]
+    fn empty_classes_stay_empty() {
+        let mut layer = Layer::new("pts");
+        layer
+            .add_feature(Some(Geometry::point(0.0, 0.0)), &[])
+            .unwrap();
+        let b = build(&layer);
+        assert!(b.line_path_indices().is_empty());
+        assert!(b.polygon_indices().is_empty());
+        assert!(b.polygon_primitive_polygon_indices().is_empty());
+    }
+}

--- a/crates/geolibre-wasm/src/geoparquet_mem.rs
+++ b/crates/geolibre-wasm/src/geoparquet_mem.rs
@@ -1,0 +1,487 @@
+//! In-memory GeoParquet reader.
+//!
+//! `wbvector::geoparquet::read` takes a `Path`, which is unusable in the
+//! browser: the wasm32-unknown-unknown build has no filesystem at all. This
+//! module reads the same format straight from a byte buffer, so a fetched or
+//! drag-and-dropped `.parquet` can be decoded client-side and fed to every
+//! other vector entry point (GeoJSON, binary attributes, Arrow IPC).
+//!
+//! Scope matches the upstream reader: WKB geometry in a binary column named by
+//! the `geo` file metadata (default `geometry`), scalar attribute columns, and
+//! the GeoParquet 1.1 `bbox` covering column skipped on read.
+
+use std::collections::HashMap;
+
+use parquet::basic::{ConvertedType, Type as PhysicalType};
+use parquet::file::metadata::KeyValue;
+use parquet::file::reader::{FileReader, SerializedFileReader};
+use parquet::record::{Field, Row};
+use serde_json::Value;
+use wbvector::feature::{FieldDef, FieldType, FieldValue, Layer};
+use wbvector::geometry::Geometry;
+
+/// Name of the GeoParquet 1.1 bbox covering column (a `struct<xmin, ymin,
+/// xmax, ymax>`), written next to the geometry column and skipped on read.
+const BBOX_COL: &str = "bbox";
+/// Key under which the upstream writer records exact wbvector field types,
+/// which Parquet's own type system cannot represent (Date vs DateTime vs Text).
+const WBVECTOR_FIELD_TYPES_KEY: &str = "wbvector_field_types";
+
+/// Read a GeoParquet dataset from bytes into a [`Layer`].
+pub fn from_bytes(data: &[u8]) -> Result<Layer, String> {
+    let reader = SerializedFileReader::new(bytes::Bytes::from(data.to_vec()))
+        .map_err(|e| format!("failed opening parquet bytes: {e}"))?;
+
+    let file_meta = reader.metadata().file_metadata();
+    let kv_meta = file_meta.key_value_metadata().map(|v| v.as_slice());
+    let geo_meta = parse_geo_metadata(kv_meta)?;
+    let declared_types = parse_wbvector_field_types(kv_meta);
+    let geom_col = geo_meta
+        .primary_column
+        .clone()
+        .unwrap_or_else(|| "geometry".to_owned());
+    let schema_types = infer_types_from_schema(file_meta, &geom_col);
+
+    // Column order comes from the file schema; any column that only shows up in
+    // the row data (nested/edge cases) is appended as it is encountered.
+    let mut ordered_attr_names: Vec<String> = file_meta
+        .schema_descr()
+        .columns()
+        .iter()
+        .filter_map(|c| {
+            // The bbox covering is a struct, so its leaves are nested (path
+            // ["bbox", "xmin"]); a user attribute named "bbox" is a top-level
+            // scalar, so requiring nesting keeps it from being dropped.
+            let parts = c.path().parts();
+            let root = parts.first().map(String::as_str);
+            let is_covering_leaf = root == Some(BBOX_COL) && parts.len() >= 2;
+            if root == Some(geom_col.as_str()) || is_covering_leaf {
+                None
+            } else {
+                Some(c.name().to_owned())
+            }
+        })
+        .collect();
+
+    let rows: Vec<Row> = reader
+        .get_row_iter(None)
+        .map_err(|e| format!("failed to iterate rows: {e}"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("failed reading parquet row: {e}"))?;
+
+    let mut inferred_types: HashMap<String, FieldType> = HashMap::new();
+    for name in &ordered_attr_names {
+        if let Some(t) = declared_types.get(name).or_else(|| schema_types.get(name)) {
+            inferred_types.insert(name.clone(), *t);
+        }
+    }
+    for row in &rows {
+        for (name, field) in row.get_column_iter() {
+            if name.as_str() == geom_col.as_str() || is_bbox_covering(name, field) {
+                continue;
+            }
+            if !ordered_attr_names.iter().any(|n| n == name) {
+                ordered_attr_names.push(name.clone());
+            }
+            let inferred = declared_types
+                .get(name)
+                .copied()
+                .or_else(|| schema_types.get(name).copied())
+                .unwrap_or_else(|| infer_field_type(field));
+            let entry = inferred_types.entry(name.clone()).or_insert(inferred);
+            *entry = FieldValue::widen_type(*entry, inferred);
+        }
+    }
+
+    let mut layer = Layer::new("layer");
+    if let Some(epsg) = geo_meta.epsg {
+        layer = layer.with_crs_epsg(epsg);
+    }
+    if let Some(wkt) = geo_meta.wkt {
+        layer = layer.with_crs_wkt(wkt);
+    }
+    for name in &ordered_attr_names {
+        let ty = inferred_types.get(name).copied().unwrap_or(FieldType::Text);
+        layer.add_field(FieldDef::new(name, ty));
+    }
+
+    for (idx, row) in rows.into_iter().enumerate() {
+        let mut geom = None;
+        let mut attrs = vec![FieldValue::Null; layer.schema.len()];
+
+        for (name, field) in row.get_column_iter() {
+            if is_bbox_covering(name, field) {
+                continue;
+            }
+            if name.as_str() == geom_col.as_str() {
+                geom = geometry_from_field(field)?;
+            } else if let Some(i) = layer.schema.field_index(name) {
+                let hinted = layer.schema.fields()[i].field_type;
+                attrs[i] = field_to_value_with_hint(field, hinted);
+            }
+        }
+
+        if layer.geom_type.is_none() {
+            if let Some(g) = &geom {
+                layer.geom_type = Some(g.geom_type());
+            }
+        }
+
+        layer
+            .add_feature(geom, &[])
+            .map_err(|e| format!("failed adding feature: {e}"))?;
+        if let Some(f) = layer.features.get_mut(idx) {
+            f.fid = idx as u64;
+            f.attributes = attrs;
+        }
+    }
+
+    Ok(layer)
+}
+
+fn is_bbox_covering(name: &str, field: &Field) -> bool {
+    name == BBOX_COL && matches!(field, Field::Group(_))
+}
+
+fn geometry_from_field(field: &Field) -> Result<Option<Geometry>, String> {
+    match field {
+        Field::Null => Ok(None),
+        Field::Bytes(bytes) => Geometry::from_wkb(bytes.data())
+            .map(Some)
+            .map_err(|e| format!("invalid WKB geometry: {e}")),
+        other => Err(format!(
+            "geometry column must be binary WKB, found {other:?}"
+        )),
+    }
+}
+
+fn infer_field_type(field: &Field) -> FieldType {
+    match field {
+        Field::Bool(_) => FieldType::Boolean,
+        Field::Byte(_) | Field::Short(_) | Field::Int(_) | Field::Long(_) => FieldType::Integer,
+        Field::UByte(_) | Field::UShort(_) | Field::UInt(_) | Field::ULong(_) => FieldType::Integer,
+        Field::Float(_) | Field::Double(_) => FieldType::Float,
+        Field::Bytes(_) => FieldType::Blob,
+        _ => FieldType::Text,
+    }
+}
+
+fn field_to_value(field: &Field) -> FieldValue {
+    match field {
+        Field::Null => FieldValue::Null,
+        Field::Bool(v) => FieldValue::Boolean(*v),
+        Field::Byte(v) => FieldValue::Integer(*v as i64),
+        Field::Short(v) => FieldValue::Integer(*v as i64),
+        Field::Int(v) => FieldValue::Integer(*v as i64),
+        Field::Long(v) => FieldValue::Integer(*v),
+        Field::UByte(v) => FieldValue::Integer(*v as i64),
+        Field::UShort(v) => FieldValue::Integer(*v as i64),
+        Field::UInt(v) => FieldValue::Integer(*v as i64),
+        Field::ULong(v) => FieldValue::Integer(*v as i64),
+        Field::Float(v) => FieldValue::Float(*v as f64),
+        Field::Double(v) => FieldValue::Float(*v),
+        Field::Str(v) => FieldValue::Text(v.clone()),
+        Field::Bytes(v) => FieldValue::Blob(v.data().to_vec()),
+        other => FieldValue::Text(format!("{other:?}")),
+    }
+}
+
+fn field_to_value_with_hint(field: &Field, hint: FieldType) -> FieldValue {
+    match (hint, field_to_value(field)) {
+        (FieldType::Date, FieldValue::Text(s)) => FieldValue::Date(s),
+        (FieldType::DateTime, FieldValue::Text(s)) => FieldValue::DateTime(s),
+        (_, v) => v,
+    }
+}
+
+fn parse_wbvector_field_types(kv: Option<&[KeyValue]>) -> HashMap<String, FieldType> {
+    let mut out = HashMap::new();
+    let Some(raw) = kv.and_then(|pairs| {
+        pairs
+            .iter()
+            .find(|p| p.key == WBVECTOR_FIELD_TYPES_KEY)
+            .and_then(|p| p.value.clone())
+    }) else {
+        return out;
+    };
+    // A malformed hint block is not fatal: fall back to schema inference.
+    let Ok(Value::Object(obj)) = serde_json::from_str::<Value>(&raw) else {
+        return out;
+    };
+    for (name, value) in obj {
+        if let Some(t) = value.as_str().and_then(parse_field_type_name) {
+            out.insert(name, t);
+        }
+    }
+    out
+}
+
+fn parse_field_type_name(s: &str) -> Option<FieldType> {
+    Some(match s {
+        "Integer" => FieldType::Integer,
+        "Float" => FieldType::Float,
+        "Text" => FieldType::Text,
+        "Boolean" => FieldType::Boolean,
+        "Blob" => FieldType::Blob,
+        "Date" => FieldType::Date,
+        "DateTime" => FieldType::DateTime,
+        "Json" => FieldType::Json,
+        _ => return None,
+    })
+}
+
+fn infer_types_from_schema(
+    file_meta: &parquet::file::metadata::FileMetaData,
+    geom_col: &str,
+) -> HashMap<String, FieldType> {
+    let mut out = HashMap::new();
+    for col in file_meta.schema_descr().columns() {
+        let name = col.name();
+        if name == geom_col {
+            continue;
+        }
+        let ty = match col.converted_type() {
+            ConvertedType::JSON => FieldType::Json,
+            ConvertedType::UTF8 => FieldType::Text,
+            ConvertedType::DATE => FieldType::Date,
+            _ => match col.physical_type() {
+                PhysicalType::BOOLEAN => FieldType::Boolean,
+                PhysicalType::INT32 | PhysicalType::INT64 => FieldType::Integer,
+                PhysicalType::FLOAT | PhysicalType::DOUBLE => FieldType::Float,
+                PhysicalType::BYTE_ARRAY | PhysicalType::FIXED_LEN_BYTE_ARRAY => FieldType::Blob,
+                _ => FieldType::Text,
+            },
+        };
+        out.insert(name.to_owned(), ty);
+    }
+    out
+}
+
+#[derive(Debug, Default)]
+struct GeoMeta {
+    primary_column: Option<String>,
+    epsg: Option<u32>,
+    wkt: Option<String>,
+}
+
+fn parse_geo_metadata(kv: Option<&[KeyValue]>) -> Result<GeoMeta, String> {
+    let mut meta = GeoMeta::default();
+    let Some(raw) = kv.and_then(|pairs| {
+        pairs
+            .iter()
+            .find(|p| p.key == "geo")
+            .and_then(|p| p.value.clone())
+    }) else {
+        return Ok(meta);
+    };
+
+    let v: Value =
+        serde_json::from_str(&raw).map_err(|e| format!("invalid 'geo' metadata JSON: {e}"))?;
+    meta.primary_column = v
+        .get("primary_column")
+        .and_then(|x| x.as_str())
+        .map(ToOwned::to_owned);
+
+    if let Some(pc) = meta.primary_column.clone() {
+        if let Some(col) = v.get("columns").and_then(|c| c.get(&pc)) {
+            parse_crs_hint(col, &mut meta);
+        }
+    }
+    Ok(meta)
+}
+
+/// Resolve the column's `crs` entry to an EPSG code where possible. Handles the
+/// three shapes GeoParquet writers emit: an SRS reference string
+/// (`"EPSG:4326"`, `"OGC:CRS84"`), a PROJJSON object with an `id`, and raw WKT.
+fn parse_crs_hint(col_meta: &Value, out: &mut GeoMeta) {
+    let Some(crs_v) = col_meta.get("crs") else {
+        return;
+    };
+
+    if let Some(s) = crs_v.as_str() {
+        match epsg_from_srs_reference(s) {
+            Some(epsg) => out.epsg = Some(epsg),
+            None => match epsg_from_wkt_lenient(s) {
+                Some(epsg) => out.epsg = Some(epsg),
+                None => out.wkt = Some(s.to_owned()),
+            },
+        }
+        return;
+    }
+
+    if let Some(obj) = crs_v.as_object() {
+        if let Some(wkt) = obj.get("wkt").and_then(|x| x.as_str()) {
+            out.wkt = Some(wkt.to_owned());
+            out.epsg = epsg_from_wkt_lenient(wkt);
+            return;
+        }
+        if let Some(id) = obj.get("id") {
+            let authority = id
+                .get("authority")
+                .and_then(|a| a.as_str())
+                .unwrap_or_default();
+            if authority.eq_ignore_ascii_case("EPSG") {
+                out.epsg = id.get("code").and_then(|c| c.as_u64()).map(|c| c as u32);
+            }
+        }
+    }
+}
+
+/// `"EPSG:4326"` / `"urn:ogc:def:crs:EPSG::4326"` / `"OGC:CRS84"` -> EPSG code.
+fn epsg_from_srs_reference(s: &str) -> Option<u32> {
+    let t = s.trim();
+    if t.eq_ignore_ascii_case("OGC:CRS84")
+        || t.eq_ignore_ascii_case("urn:ogc:def:crs:OGC:1.3:CRS84")
+    {
+        // CRS84 is WGS84 with lon/lat axis order, which is the order every
+        // reader here already uses.
+        return Some(4326);
+    }
+    let upper = t.to_ascii_uppercase();
+    let code = upper.rsplit_once("EPSG:")?.1.trim_start_matches(':');
+    code.parse().ok()
+}
+
+/// Pull the EPSG code out of the trailing `AUTHORITY["EPSG","4326"]` (WKT1) or
+/// `ID["EPSG",4326]` (WKT2) node without a full WKT parse.
+fn epsg_from_wkt_lenient(wkt: &str) -> Option<u32> {
+    let upper = wkt.to_ascii_uppercase();
+    let start = upper.rfind("AUTHORITY[").or_else(|| upper.rfind("ID["))?;
+    let tail = &wkt[start..];
+    let inner = tail.split_once('[')?.1;
+    let inner = inner.split(']').next()?;
+    let mut parts = inner.split(',');
+    let authority = parts.next()?.trim().trim_matches('"');
+    if !authority.eq_ignore_ascii_case("EPSG") {
+        return None;
+    }
+    parts.next()?.trim().trim_matches('"').parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wbvector::feature::FieldDef;
+    use wbvector::geometry::GeometryType;
+
+    /// End-to-end check against the format the upstream writer actually emits
+    /// (WKB geometry, `geo` metadata, bbox covering column, field-type hints).
+    #[test]
+    fn reads_geoparquet_written_by_the_upstream_writer() {
+        let mut layer = Layer::new("cities")
+            .with_geom_type(GeometryType::Point)
+            .with_crs_epsg(4326);
+        layer.add_field(FieldDef::new("name", FieldType::Text));
+        layer.add_field(FieldDef::new("pop", FieldType::Integer));
+        layer.add_field(FieldDef::new("area", FieldType::Float));
+        layer
+            .add_feature(
+                Some(Geometry::point(-0.1278, 51.5074)),
+                &[
+                    ("name", "London".into()),
+                    ("pop", 9_000_000i64.into()),
+                    ("area", 1572.0.into()),
+                ],
+            )
+            .unwrap();
+        layer
+            .add_feature(
+                Some(Geometry::point(10.7522, 59.9139)),
+                &[
+                    ("name", "Oslo".into()),
+                    ("pop", 700_000i64.into()),
+                    ("area", 454.0.into()),
+                ],
+            )
+            .unwrap();
+
+        let path = std::env::temp_dir().join("geolibre_geoparquet_mem_roundtrip.parquet");
+        wbvector::geoparquet::write(&layer, &path).unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        let back = from_bytes(&bytes).unwrap();
+        assert_eq!(back.len(), 2);
+        assert_eq!(back.crs_epsg(), Some(4326));
+        assert_eq!(back.geom_type, Some(GeometryType::Point));
+
+        let names: Vec<&str> = back
+            .schema
+            .fields()
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["name", "pop", "area"]);
+        // The bbox covering column must not leak in as an attribute.
+        assert!(!names.contains(&"bbox"));
+
+        let first = &back.features[0];
+        assert_eq!(
+            first.get(&back.schema, "name").unwrap().as_str(),
+            Some("London")
+        );
+        assert_eq!(
+            first.get(&back.schema, "pop").unwrap().as_i64(),
+            Some(9_000_000)
+        );
+        assert_eq!(
+            first.get(&back.schema, "area").unwrap().as_f64(),
+            Some(1572.0)
+        );
+        match first.geometry.as_ref().unwrap() {
+            Geometry::Point(c) => {
+                assert!((c.x - -0.1278).abs() < 1e-9);
+                assert!((c.y - 51.5074).abs() < 1e-9);
+            }
+            other => panic!("expected a point, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_bytes_that_are_not_parquet() {
+        assert!(from_bytes(b"definitely not parquet").is_err());
+    }
+
+    #[test]
+    fn srs_reference_forms_resolve_to_epsg() {
+        assert_eq!(epsg_from_srs_reference("EPSG:3857"), Some(3857));
+        assert_eq!(epsg_from_srs_reference("epsg:4326"), Some(4326));
+        assert_eq!(
+            epsg_from_srs_reference("urn:ogc:def:crs:EPSG::32617"),
+            Some(32617)
+        );
+        assert_eq!(epsg_from_srs_reference("OGC:CRS84"), Some(4326));
+        assert_eq!(epsg_from_srs_reference("not a crs"), None);
+    }
+
+    #[test]
+    fn wkt_authority_node_resolves_to_epsg() {
+        let wkt1 = r#"GEOGCS["WGS 84",DATUM["WGS_1984"],AUTHORITY["EPSG","4326"]]"#;
+        assert_eq!(epsg_from_wkt_lenient(wkt1), Some(4326));
+        let wkt2 = r#"PROJCRS["WGS 84 / UTM zone 17N",ID["EPSG",32617]]"#;
+        assert_eq!(epsg_from_wkt_lenient(wkt2), Some(32617));
+        let other = r#"PROJCRS["local",ID["ESRI",102008]]"#;
+        assert_eq!(epsg_from_wkt_lenient(other), None);
+    }
+
+    #[test]
+    fn crs_hint_reads_projjson_id() {
+        let col: Value =
+            serde_json::from_str(r#"{"crs":{"id":{"authority":"EPSG","code":3857}}}"#).unwrap();
+        let mut meta = GeoMeta::default();
+        parse_crs_hint(&col, &mut meta);
+        assert_eq!(meta.epsg, Some(3857));
+    }
+
+    #[test]
+    fn field_type_hints_round_trip_through_names() {
+        for (name, ty) in [
+            ("Integer", FieldType::Integer),
+            ("Float", FieldType::Float),
+            ("DateTime", FieldType::DateTime),
+        ] {
+            assert_eq!(parse_field_type_name(name), Some(ty));
+        }
+        assert_eq!(parse_field_type_name("Nonsense"), None);
+    }
+}

--- a/crates/geolibre-wasm/src/lib.rs
+++ b/crates/geolibre-wasm/src/lib.rs
@@ -9,6 +9,11 @@
 //!   [`geotiff_read_band_f64`]) for one-shot use.
 //! - **Stateful classes** ([`GeoTiffReader`] parses once and serves many reads;
 //!   [`CogBuilder`] encodes Cloud Optimized GeoTIFFs to bytes).
+#[cfg(feature = "arrow")]
+mod arrow_ipc;
+mod binary;
+#[cfg(feature = "geoparquet")]
+mod geoparquet_mem;
 mod vector;
 mod lidar;
 mod analysis;

--- a/crates/geolibre-wasm/src/vector.rs
+++ b/crates/geolibre-wasm/src/vector.rs
@@ -2,8 +2,12 @@
 //! and optional reprojection. Backed by the pure-Rust `wbvector` engine.
 //!
 //! In-memory formats: GeoJSON, TopoJSON, GML, GPX, KML (text); FlatGeobuf,
-//! GeoPackage, KMZ (binary). Shapefile / GeoParquet / MapInfo / OSM-PBF are
+//! GeoPackage, GeoParquet, KMZ (binary). Shapefile / MapInfo / OSM-PBF are
 //! file-oriented in the engine and not yet exposed here.
+//!
+//! Every reader here feeds three output paths, all sharing [`read_layer`]:
+//! GeoJSON text (this module), deck.gl binary attributes
+//! ([`crate::binary`]), and Arrow IPC ([`crate::arrow_ipc`]).
 use wasm_bindgen::prelude::*;
 use wbvector::Layer;
 
@@ -12,7 +16,7 @@ fn jerr<E: std::fmt::Display>(ctx: &str) -> impl Fn(E) -> JsValue + '_ {
 }
 
 /// Parse a vector dataset (bytes + format name) into a `Layer`.
-fn read_layer(data: &[u8], format: &str) -> Result<Layer, JsValue> {
+pub(crate) fn read_layer(data: &[u8], format: &str) -> Result<Layer, JsValue> {
     let as_text = || std::str::from_utf8(data)
         .map_err(|_| JsValue::from_str("text vector format requires valid UTF-8"));
     let layer = match format.to_lowercase().as_str() {
@@ -24,16 +28,48 @@ fn read_layer(data: &[u8], format: &str) -> Result<Layer, JsValue> {
         "flatgeobuf" | "fgb" => wbvector::flatgeobuf::from_bytes(data),
         "geopackage" | "gpkg" => wbvector::geopackage::from_bytes(data.to_vec()),
         "kmz" => wbvector::kmz::from_bytes(data),
+        // Upstream's GeoParquet reader is path-based, which the browser build
+        // has no filesystem for; read it from the buffer instead.
+        #[cfg(feature = "geoparquet")]
+        "geoparquet" | "parquet" => {
+            return crate::geoparquet_mem::from_bytes(data)
+                .map_err(|e| JsValue::from_str(&format!("read: {e}")))
+        }
+        #[cfg(not(feature = "geoparquet"))]
+        "geoparquet" | "parquet" => return Err(JsValue::from_str(
+            "this build was compiled without the 'geoparquet' feature")),
         other => return Err(JsValue::from_str(&format!(
-            "unsupported vector format '{other}' (try: geojson, topojson, gml, gpx, kml, flatgeobuf, geopackage, kmz)"))),
+            "unsupported vector format '{other}' (try: {})", vector_formats()))),
     };
     layer.map_err(jerr("read"))
+}
+
+/// Apply the reprojection convention shared by every vector entry point:
+/// `src_epsg` of `0` means "use the layer's own CRS", falling back to EPSG:4326
+/// when it declares none (GeoJSON is WGS84 by RFC 7946).
+pub(crate) fn reproject_layer(
+    layer: Layer,
+    dst_epsg: u32,
+    src_epsg: u32,
+) -> Result<Layer, JsValue> {
+    let src = if src_epsg != 0 {
+        src_epsg
+    } else {
+        layer.crs_epsg().unwrap_or(4326)
+    };
+    layer
+        .reproject_from_to_epsg(src, dst_epsg)
+        .map_err(jerr("reproject"))
 }
 
 /// Vector formats this build can read from memory (comma-separated).
 #[wasm_bindgen]
 pub fn vector_formats() -> String {
-    "geojson,topojson,gml,gpx,kml,flatgeobuf,geopackage,kmz".to_string()
+    let mut formats = "geojson,topojson,gml,gpx,kml,flatgeobuf,geopackage,kmz".to_string();
+    if cfg!(feature = "geoparquet") {
+        formats.push_str(",geoparquet");
+    }
+    formats
 }
 
 /// Read a vector dataset and return it as a GeoJSON `FeatureCollection` string.
@@ -55,12 +91,7 @@ pub fn vector_to_geojson_reproject(
     src_epsg: u32,
 ) -> Result<String, JsValue> {
     let layer = read_layer(data, format)?;
-    let src = if src_epsg != 0 { Some(src_epsg) } else { layer.crs_epsg() };
-    let rep = match src {
-        Some(s) => layer.reproject_from_to_epsg(s, dst_epsg),
-        None => layer.reproject_from_to_epsg(4326, dst_epsg),
-    }
-    .map_err(jerr("reproject"))?;
+    let rep = reproject_layer(layer, dst_epsg, src_epsg)?;
     Ok(wbvector::geojson::to_string(&rep))
 }
 

--- a/demo/benchmark.html
+++ b/demo/benchmark.html
@@ -1,0 +1,394 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>geolibre-rust — vector interop benchmark</title>
+    <!-- apache-arrow is only needed to prove the Arrow IPC bytes parse
+         zero-copy on the JS side; the page still works without it. -->
+    <script type="importmap">
+      {
+        "imports": {
+          "apache-arrow": "https://esm.sh/apache-arrow@21.0.0"
+        }
+      }
+    </script>
+    <style>
+      :root { color-scheme: light dark; --line: rgba(127,127,127,0.3); --soft: rgba(127,127,127,0.12); }
+      * { box-sizing: border-box; }
+      body { font-family: system-ui, sans-serif; max-width: 1080px; margin: 2rem auto; padding: 0 1rem; line-height: 1.5; }
+      h1 { margin-bottom: 0.25rem; }
+      h2 { margin: 1.5rem 0 0.5rem; font-size: 1.05rem; }
+      .muted { opacity: 0.7; }
+      button { font: inherit; padding: 0.5rem 1rem; cursor: pointer; border-radius: 6px; border: 1px solid var(--line); background: var(--soft); }
+      button.primary { background: #2563eb; color: #fff; border-color: #2563eb; }
+      button:disabled { opacity: 0.5; cursor: default; }
+      input, select { font: inherit; padding: 0.4rem 0.6rem; border: 1px solid var(--line); border-radius: 6px; background: transparent; color: inherit; }
+      select, select option { color-scheme: light dark; background-color: Field; color: FieldText; }
+      label { font-size: 0.85rem; font-weight: 600; display: block; margin-bottom: 0.2rem; }
+      .row { display: flex; gap: 0.75rem; align-items: flex-end; flex-wrap: wrap; margin: 0.75rem 0; }
+      .panel { border: 1px solid var(--line); border-radius: 8px; padding: 1rem 1.1rem; margin: 1rem 0; }
+      table { border-collapse: collapse; width: 100%; font-variant-numeric: tabular-nums; }
+      th, td { text-align: right; padding: 0.4rem 0.6rem; border-bottom: 1px solid var(--line); }
+      th:first-child, td:first-child { text-align: left; }
+      tbody tr.best td { font-weight: 700; }
+      .bar { height: 0.5rem; border-radius: 999px; background: #2563eb; display: block; }
+      pre { background: var(--soft); padding: 0.75rem; border-radius: 6px; overflow: auto; white-space: pre-wrap; }
+      code { font-family: ui-monospace, monospace; }
+      .note { font-size: 0.85rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Vector interop benchmark</h1>
+    <p class="muted">
+      The same source bytes, read once per path by the same pure-Rust engine, delivered to
+      JavaScript three different ways. What is being measured is the <em>handoff</em>: how long
+      until the main thread holds coordinates a GPU could draw.
+    </p>
+    <p class="note muted">
+      <strong>GeoJSON</strong> is the historical path — WASM returns a string, JS parses it, then
+      the app flattens the parsed objects into typed arrays.
+      <strong>Binary</strong> returns deck.gl's binary attribute layout directly.
+      <strong>Arrow IPC</strong> returns a GeoArrow record batch for apache-arrow / DuckDB-WASM /
+      <code>@geoarrow/deck.gl-layers</code>.
+    </p>
+
+    <div class="panel">
+      <div class="row">
+        <div>
+          <label for="source">Source</label>
+          <select id="source">
+            <option value="synthetic">Generated points</option>
+            <option value="file">Your file…</option>
+          </select>
+        </div>
+        <div id="synthetic-opts" style="display:contents">
+          <div>
+            <label for="count">Features</label>
+            <select id="count">
+              <option>10000</option>
+              <option selected>50000</option>
+              <option>190000</option>
+            </select>
+          </div>
+          <div>
+            <label for="attrs">Attributes</label>
+            <select id="attrs">
+              <option>5</option>
+              <option selected>20</option>
+              <option>53</option>
+            </select>
+          </div>
+        </div>
+        <div id="file-opts" hidden>
+          <label for="file">Vector file</label>
+          <input type="file" id="file" />
+        </div>
+        <div>
+          <label for="runs">Runs</label>
+          <select id="runs">
+            <option>1</option>
+            <option selected>3</option>
+            <option>5</option>
+          </select>
+        </div>
+        <button class="primary" id="run" disabled>Loading WASM…</button>
+      </div>
+      <p class="muted note" id="status">
+        Generated points mimic the case from
+        <a href="https://github.com/opengeos/geolibre-rust/issues/31">issue #31</a>: many points,
+        wide attribute table.
+      </p>
+    </div>
+
+    <div id="results" hidden>
+      <h2>Time to typed arrays <span class="muted" id="runs-label"></span></h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Path</th><th>WASM → JS</th><th>Parse / flatten</th><th>Total</th>
+            <th>Encoding + handoff</th><th>Payload</th><th></th>
+          </tr>
+        </thead>
+        <tbody id="rows"></tbody>
+      </table>
+      <p class="note muted" id="read-cost"></p>
+      <p class="note muted" id="verify"></p>
+    </div>
+
+    <div id="detail" hidden>
+      <h2>What each path returned</h2>
+      <pre id="detail-body"></pre>
+    </div>
+
+    <script type="module">
+      import init, {
+        vector_to_geojson,
+        vector_to_binary,
+        vector_to_arrow_ipc,
+        vector_info,
+      } from "./geolibre_wasm.js?v=__BUILD__";
+
+      const $ = (id) => document.getElementById(id);
+      const fmtMs = (ms) => (ms >= 1000 ? `${(ms / 1000).toFixed(2)} s` : `${ms.toFixed(1)} ms`);
+      const fmtBytes = (b) =>
+        b >= 1 << 20 ? `${(b / (1 << 20)).toFixed(1)} MB` : `${(b / 1024).toFixed(0)} KB`;
+      const median = (xs) => [...xs].sort((a, b) => a - b)[Math.floor(xs.length / 2)];
+
+      let tableFromIPC = null;
+      try {
+        ({ tableFromIPC } = await import("apache-arrow"));
+      } catch {
+        // Offline: still time the IPC bytes, just skip the JS-side parse.
+      }
+
+      await init({ module_or_path: "./geolibre_wasm_bg.wasm?v=__BUILD__" });
+      $("run").disabled = false;
+      $("run").textContent = "Run benchmark";
+
+      $("source").addEventListener("change", () => {
+        const file = $("source").value === "file";
+        $("synthetic-opts").style.display = file ? "none" : "contents";
+        $("file-opts").hidden = !file;
+      });
+
+      // ── source data ────────────────────────────────────────────────────────
+
+      // A GeoJSON FeatureCollection is the honest common input: every path then
+      // reads the identical bytes through the identical Rust reader, so the only
+      // difference measured is how the result crosses into JavaScript.
+      function syntheticGeoJson(count, attrCount) {
+        const parts = ['{"type":"FeatureCollection","features":['];
+        for (let i = 0; i < count; i++) {
+          // Deterministic pseudo-random spread — no Math.random, so repeated
+          // runs are comparable.
+          const lon = (((i * 2654435761) % 3600000) / 10000 - 180).toFixed(5);
+          const lat = (((i * 40503) % 1700000) / 10000 - 85).toFixed(5);
+          const props = [];
+          for (let a = 0; a < attrCount; a++) {
+            props.push(
+              a % 3 === 0
+                ? `"attr_${a}":${(i * (a + 1)) % 100000}`
+                : a % 3 === 1
+                  ? `"attr_${a}":${(((i * (a + 7)) % 10000) / 100).toFixed(2)}`
+                  : `"attr_${a}":"value_${(i * (a + 3)) % 997}"`,
+            );
+          }
+          parts.push(
+            `${i ? "," : ""}{"type":"Feature","geometry":{"type":"Point","coordinates":[${lon},${lat}]},"properties":{${props.join(",")}}}`,
+          );
+        }
+        parts.push("]}");
+        return new TextEncoder().encode(parts.join(""));
+      }
+
+      function formatFor(name) {
+        const ext = String(name).split(".").pop().toLowerCase();
+        return (
+          { geojson: "geojson", json: "geojson", fgb: "flatgeobuf", gpkg: "geopackage",
+            parquet: "geoparquet", kml: "kml", kmz: "kmz", gpx: "gpx", gml: "gml",
+            topojson: "topojson" }[ext] ?? "geojson"
+        );
+      }
+
+      // ── the three paths ────────────────────────────────────────────────────
+
+      // Historical path: string out, JSON.parse, then flatten to typed arrays —
+      // the work an app does before it can hand anything to the GPU.
+      function runGeoJson(bytes, format) {
+        const t0 = performance.now();
+        const text = vector_to_geojson(bytes, format);
+        const t1 = performance.now();
+        const fc = JSON.parse(text);
+        const n = fc.features.length;
+        const positions = new Float64Array(n * 2);
+        const firstNumeric = new Float64Array(n);
+        let key = null;
+        for (let i = 0; i < n; i++) {
+          const f = fc.features[i];
+          const c = f.geometry?.coordinates ?? [NaN, NaN];
+          positions[2 * i] = c[0];
+          positions[2 * i + 1] = c[1];
+          if (key === null) key = Object.keys(f.properties ?? {})[0] ?? "";
+          firstNumeric[i] = Number(f.properties?.[key]);
+        }
+        const t2 = performance.now();
+        return {
+          produce: t1 - t0,
+          parse: t2 - t1,
+          bytes: text.length,
+          features: n,
+          positions,
+        };
+      }
+
+      // Binary path: typed arrays straight out of WASM, nothing to parse.
+      // Every attribute column is materialized, so the payload and the timing
+      // stay comparable with Arrow, which carries the whole table.
+      function runBinary(bytes, format) {
+        const t0 = performance.now();
+        const b = vector_to_binary(bytes, format);
+        const t1 = performance.now();
+        const positions = b.point_positions();
+        let payload = positions.byteLength + b.point_feature_ids().byteLength;
+        const schema = JSON.parse(b.schema_json);
+        schema.forEach((field, i) => {
+          if (field.type === "Integer" || field.type === "Float" || field.type === "Boolean") {
+            payload += b.numeric_column(i).byteLength;
+          } else {
+            payload += b.text_column(i).byteLength + b.text_column_offsets(i).byteLength;
+          }
+        });
+        const t2 = performance.now();
+        const featureCount = b.feature_count;
+        b.free();
+        return { produce: t1 - t0, parse: t2 - t1, bytes: payload, features: featureCount, positions };
+      }
+
+      // Arrow path: one GeoArrow record batch, consumable by apache-arrow and
+      // DuckDB-WASM without a copy.
+      function runArrow(bytes, format) {
+        const t0 = performance.now();
+        const ipc = vector_to_arrow_ipc(bytes, format);
+        const t1 = performance.now();
+        let features = null;
+        let positions = null;
+        if (tableFromIPC) {
+          const table = tableFromIPC(ipc);
+          features = table.numRows;
+          // Interleaved geoarrow.point coordinates: one flat Float64Array.
+          const geom = table.getChild("geometry");
+          positions = geom?.getChildAt(0)?.toArray() ?? null;
+        }
+        const t2 = performance.now();
+        return { produce: t1 - t0, parse: t2 - t1, bytes: ipc.byteLength, features, positions };
+      }
+
+      // ── driver ─────────────────────────────────────────────────────────────
+
+      $("run").addEventListener("click", async () => {
+        const btn = $("run");
+        btn.disabled = true;
+        const runs = Number($("runs").value);
+
+        let bytes, format, label;
+        if ($("source").value === "file") {
+          const f = $("file").files?.[0];
+          if (!f) {
+            $("status").textContent = "Pick a file first.";
+            btn.disabled = false;
+            return;
+          }
+          $("status").textContent = `Reading ${f.name}…`;
+          await new Promise((r) => setTimeout(r));
+          bytes = new Uint8Array(await f.arrayBuffer());
+          format = formatFor(f.name);
+          label = `${f.name} (${format})`;
+        } else {
+          const count = Number($("count").value);
+          const attrs = Number($("attrs").value);
+          $("status").textContent = `Generating ${count.toLocaleString()} features × ${attrs} attributes…`;
+          await new Promise((r) => setTimeout(r));
+          bytes = syntheticGeoJson(count, attrs);
+          format = "geojson";
+          label = `${count.toLocaleString()} points × ${attrs} attributes`;
+        }
+
+        $("status").textContent = `Benchmarking ${label} — source ${fmtBytes(bytes.byteLength)}…`;
+        await new Promise((r) => setTimeout(r));
+
+        // Decoding the source is shared work: every path runs the same Rust
+        // reader first. Time it on its own so the table can separate it from
+        // the part that actually differs — how the layer crosses into JS.
+        const readSamples = [];
+        for (let i = 0; i < runs; i++) {
+          const t0 = performance.now();
+          vector_info(bytes, format);
+          readSamples.push(performance.now() - t0);
+        }
+        const readCost = median(readSamples);
+
+        const paths = [
+          ["GeoJSON string + JSON.parse", runGeoJson],
+          ["Binary (typed arrays)", runBinary],
+          ["Arrow IPC (GeoArrow)", runArrow],
+        ];
+        const results = [];
+        for (const [name, fn] of paths) {
+          const samples = [];
+          let last = null;
+          for (let i = 0; i < runs; i++) {
+            last = fn(bytes, format);
+            samples.push(last);
+          }
+          results.push({
+            name,
+            produce: median(samples.map((s) => s.produce)),
+            parse: median(samples.map((s) => s.parse)),
+            bytes: last.bytes,
+            features: last.features,
+            positions: last.positions,
+          });
+        }
+
+        for (const r of results) r.total = r.produce + r.parse;
+        // The shared read is inside every path's WASM call; what is left is the
+        // encode-and-cross-the-boundary cost that actually differs. On small
+        // inputs the read swamps everything and the subtraction is pure noise,
+        // so say so rather than printing a fabricated 0.
+        const separable = readCost < Math.min(...results.map((r) => r.total));
+        for (const r of results) r.handoff = separable ? r.total - readCost : r.total;
+        const fastest = Math.min(...results.map((r) => r.handoff));
+        const slowest = Math.max(...results.map((r) => r.handoff));
+
+        $("rows").innerHTML = results
+          .map((r) => {
+            const parse =
+              r.name.startsWith("Arrow") && !tableFromIPC ? "<span class='muted'>n/a</span>" : fmtMs(r.parse);
+            const ratio =
+              r.handoff === fastest ? "" : ` <span class="muted">(${(r.handoff / fastest).toFixed(1)}×)</span>`;
+            return `<tr class="${r.handoff === fastest ? "best" : ""}">
+              <td>${r.name}</td>
+              <td>${fmtMs(r.produce)}</td>
+              <td>${parse}</td>
+              <td>${fmtMs(r.total)}</td>
+              <td>${separable ? fmtMs(r.handoff) : "<span class='muted'>—</span>"}${ratio}</td>
+              <td>${fmtBytes(r.bytes)}</td>
+              <td style="width:22%"><span class="bar" style="width:${Math.max(2, (r.handoff / slowest) * 100)}%"></span></td>
+            </tr>`;
+          })
+          .join("");
+        $("read-cost").textContent =
+          `Every path first decodes the source with the same Rust reader — ${fmtMs(readCost)} here, ` +
+          `included in the "WASM → JS" and "Total" columns. ` +
+          (separable
+            ? `"Encoding + handoff" subtracts it, leaving the part that differs between paths.`
+            : `At this size the read dominates the totals, so subtracting it would be noise rather than a ` +
+              `measurement; the ratios below rank totals instead. Try a larger input.`) +
+          ` The GeoJSON row is charitable: it flattens coordinates and one attribute column, and leaves the ` +
+          `rest of the attributes as the objects JSON.parse already built, while the binary and Arrow rows ` +
+          `materialize every column.`;
+        $("runs-label").textContent = `— median of ${runs} run${runs > 1 ? "s" : ""}, ${label}`;
+        $("results").hidden = false;
+
+        // Honest comparison check: the paths must agree on what they produced.
+        const counts = results.map((r) => r.features).filter((c) => c !== null);
+        const agree = counts.every((c) => c === counts[0]);
+        const coord = results
+          .map((r) => r.positions)
+          .filter(Boolean)
+          .map((p) => (p.length ? `${p[0].toFixed(5)}, ${p[1].toFixed(5)}` : "—"));
+        const coordsAgree = coord.every((c) => c === coord[0]);
+        $("verify").textContent =
+          `${counts[0]?.toLocaleString() ?? "?"} features per path (${agree ? "agree" : "DISAGREE"}); ` +
+          `first coordinate ${coord[0] ?? "—"} (${coordsAgree ? "agree" : "DISAGREE"})` +
+          (tableFromIPC ? "" : "; apache-arrow unavailable offline, Arrow parse not timed");
+
+        $("detail-body").textContent = vector_info(bytes, format);
+        $("detail").hidden = false;
+        $("status").textContent = `Source: ${label}, ${fmtBytes(bytes.byteLength)} of ${format}.`;
+        btn.disabled = false;
+      });
+    </script>
+  </body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -61,6 +61,10 @@
       compiled to WebAssembly (WASI) and running entirely in your browser.
       Pick any tool, fill in its parameters, and run it on a sample DEM (or your own GeoTIFF).
     </p>
+    <p class="muted">
+      Also here: a <a href="./benchmark.html">vector interop benchmark</a> comparing GeoJSON,
+      binary typed arrays, and Arrow IPC as ways to get a layer from WASM into a map.
+    </p>
 
     <div class="row"><strong id="status">Loading WASM runtime...</strong></div>
 

--- a/demo/serve.sh
+++ b/demo/serve.sh
@@ -34,6 +34,7 @@ STAGE="$(mktemp -d)"
 trap 'rm -rf "$STAGE"' EXIT
 
 sed 's/__BUILD__/dev/g' "$DEMO_DIR/index.html" > "$STAGE/index.html"
+sed 's/__BUILD__/dev/g' "$DEMO_DIR/benchmark.html" > "$STAGE/benchmark.html"
 cp "$TOOLS_MJS" "$CLI_WASM" "$LIB_JS" "$LIB_WASM" "$SAMPLE" "$STAGE/"
 
 echo "Serving demo at http://localhost:$PORT/  (Ctrl-C to stop)"

--- a/examples/node-demo.mjs
+++ b/examples/node-demo.mjs
@@ -4,7 +4,13 @@
 //
 //   node examples/node-demo.mjs path/to/dem.tif
 import { readFile } from "node:fs/promises";
-import initLib, { version, geotiff_info } from "../npm/geolibre_wasm.js";
+import initLib, {
+  version,
+  geotiff_info,
+  vector_formats,
+  vector_to_binary,
+  vector_to_arrow_ipc,
+} from "../npm/geolibre_wasm.js";
 import { initTools, listTools, runTool } from "../npm/tools.mjs";
 
 const demPath = process.argv[2] ?? new URL("./sample.tif", import.meta.url);
@@ -16,6 +22,40 @@ console.log(`library version: ${version()}`);
 const info = JSON.parse(geotiff_info(dem));
 if (!info.ok) throw new Error("geotiff_info failed");
 console.log(`library geotiff_info: ${info.width}x${info.height}, epsg ${info.epsg}`);
+
+// ── binary vector interop: typed arrays and Arrow IPC, no GeoJSON string ──
+const sampleGeoJson = new TextEncoder().encode(
+  JSON.stringify({
+    type: "FeatureCollection",
+    features: [
+      { type: "Feature", geometry: { type: "Point", coordinates: [-0.1278, 51.5074] },
+        properties: { name: "London", pop: 9000000 } },
+      { type: "Feature", geometry: { type: "Point", coordinates: [10.7522, 59.9139] },
+        properties: { name: "Oslo", pop: 700000 } },
+    ],
+  }),
+);
+console.log(`library vector_formats: ${vector_formats()}`);
+
+const bin = vector_to_binary(sampleGeoJson, "geojson");
+const positions = bin.point_positions();
+const schema = JSON.parse(bin.schema_json);
+const popIndex = schema.findIndex((f) => f.name === "pop");
+const pops = bin.numeric_column(popIndex);
+if (!(positions instanceof Float64Array)) throw new Error("expected Float64Array positions");
+if (positions.length !== 4) throw new Error(`expected 4 position values, got ${positions.length}`);
+if (pops[0] !== 9000000) throw new Error(`expected London's pop, got ${pops[0]}`);
+console.log(
+  `library vector_to_binary: ${bin.feature_count} features, ` +
+    `${positions.length / bin.position_size} vertices, fields ${schema.map((f) => f.name).join()}`,
+);
+bin.free();
+
+const ipc = vector_to_arrow_ipc(sampleGeoJson, "geojson");
+// Arrow IPC streams start with the 0xFFFFFFFF continuation marker.
+const marker = new DataView(ipc.buffer, ipc.byteOffset, 4).getUint32(0, true);
+if (marker !== 0xffffffff) throw new Error(`not an Arrow IPC stream (marker ${marker})`);
+console.log(`library vector_to_arrow_ipc: ${ipc.length} bytes of GeoArrow IPC`);
 
 // ── tools export (./tools) ──
 await initTools(await readFile(new URL("../npm/geolibre-cli.wasm", import.meta.url)));

--- a/npm/README.md
+++ b/npm/README.md
@@ -49,6 +49,33 @@ const meta = JSON.parse(geotiff_info(tiffBytes));
 Classes include `GeoTiffReader` (parse once, read many), `CogBuilder` (encode
 Cloud Optimized GeoTIFFs), and `CogStream` (range-request tiled COG reading).
 
+### Vector data as binary, not GeoJSON
+
+`vector_to_geojson` returns a string, so the consumer pays for `JSON.parse` plus
+a re-encode into typed arrays before anything reaches the GPU. Two binary paths
+skip both steps, reading the same formats through the same reader
+(`geojson`, `topojson`, `gml`, `gpx`, `kml`, `flatgeobuf`, `geopackage`,
+`geoparquet`, `kmz` -- see `vector_formats()`):
+
+```js
+import init, { vector_to_binary, vector_to_arrow_ipc } from "geolibre-wasm";
+await init();
+
+// deck.gl binary attributes: Float64Array positions + Uint32Array indices.
+const b = vector_to_binary(bytes, "geoparquet");
+b.point_positions();          // Float64Array, position_size values per vertex
+b.numeric_column(0);          // Float64Array, one value per feature
+JSON.parse(b.schema_json);    // [{name, type}, ...]
+b.free();
+
+// GeoArrow record batch for apache-arrow, DuckDB-WASM, @geoarrow/deck.gl-layers.
+const ipc = vector_to_arrow_ipc(bytes, "flatgeobuf"); // Uint8Array
+```
+
+Reprojecting variants (`vector_to_binary_reproject`,
+`vector_to_arrow_ipc_reproject`) take `dst_epsg` and `src_epsg`, where `0`
+means "use the layer's own CRS".
+
 ## Tools usage (`./tools`)
 
 ```js


### PR DESCRIPTION
Closes the part of #31 that is actually ours to close.

The reporter's point was that keeping data binary from source to canvas is what
makes a map studio fast. geolibre-rust has no canvas, so the rendering half
belongs to GeoLibre — but the *source* half was ours, and it was the weak link:
`crates/geolibre-wasm/src/vector.rs` only emitted GeoJSON **strings**. Every
consumer paid for `JSON.parse` and then for re-encoding the parsed objects into
the typed arrays a GPU wants. The raster side of the same crate has always
handed back typed arrays (`read_band_f64` → `Float64Array`); vector was the odd
one out.

## What's new

Three outputs, all sharing one reader, so any supported format works with any of
them:

| Entry point | Returns | For |
|---|---|---|
| `vector_to_geojson` | `String` | unchanged, still the portable path |
| `vector_to_binary` | `VectorBinary` | deck.gl binary attributes |
| `vector_to_arrow_ipc` | `Uint8Array` | apache-arrow, DuckDB-WASM, `@geoarrow/deck.gl-layers` |

**`vector_to_binary`** returns `Float64Array` positions plus the `Uint32Array`
index arrays deck.gl's binary `GeoJsonLayer` expects (`path_indices`,
`polygon_indices`, `primitive_polygon_indices`, per-vertex feature ids), one set
per geometry class. Attributes come back columnar — `numeric_column(i)` as a
`Float64Array`, `text_column(i)` as UTF-8 bytes with offsets — instead of one JS
object per feature. Rings are closed on the way out so outlines draw correctly
even when the source stores them open.

**`vector_to_arrow_ipc`** emits a GeoArrow record batch: native interleaved
encoding (`geoarrow.point`/`linestring`/`polygon`/`multi*`) when the layer has a
single geometry type, `geoarrow.wkb` when it's mixed, with CRS in the extension
metadata. One representation shared by the query engine and the renderer.

**GeoParquet reads from a byte buffer.** Upstream's reader is `Path`-based,
which the `wasm32-unknown-unknown` build has no filesystem for — that's why the
module header said GeoParquet was "not yet exposed here". This reads the same
format straight from bytes (WKB geometry, `geo` metadata, GeoParquet 1.1 `bbox`
covering column skipped, field-type hints honoured) and joins the format list
for *every* vector entry point. So the cloud-native format we recommend in the
issue reply can now be consumed client-side, no server.

Reprojecting variants (`vector_to_binary_reproject`,
`vector_to_arrow_ipc_reproject`) share the reprojection convention with the
GeoJSON path, which is now factored into one helper.

## Measured, not asserted

`demo/benchmark.html` (linked from the demo index, deployed with Pages) runs all
three paths over identical source bytes. It times the shared Rust decode
separately, because on small inputs it swamps everything — where it can't be
separated cleanly the page says so instead of printing a fabricated number. The
GeoJSON row is the charitable version: it flattens coordinates and one attribute
column and leaves the rest as the objects `JSON.parse` already built, while the
binary and Arrow rows materialize every column.

50,000 points × 20 attributes, median of 3, Chromium:

| Path | Total | Encoding + handoff | Payload |
|---|---|---|---|
| GeoJSON string + `JSON.parse` | 601 ms | 232 ms (9.4×) | 20.8 MB |
| Binary (typed arrays) | 397 ms | 28 ms (1.1×) | 10.0 MB |
| Arrow IPC (GeoArrow) | 394 ms | **25 ms** | 9.9 MB |

Note what dominates the totals: ~369 ms of *decoding the GeoJSON source*, shared
by all three. That's the other half of the reporter's argument — a binary source
format matters as much as a binary handoff, which is why in-browser GeoParquet
is in this PR too.

## Bundle size

Reaching the arrow and parquet code is what costs, not linking it (both already
arrived transitively through `wbvector`'s `geoparquet` feature and were
dead-stripped). Measured on the release `wasm-pack` artifact:

| Build | Raw | Gzipped |
|---|---|---|
| before | 4.47 MB | 1.19 MB |
| after, default features | 6.44 MB | 1.94 MB |
| after, `--no-default-features` | 4.48 MB | 1.19 MB |

So both are cargo features (`arrow`, `geoparquet`), on by default — no behaviour
change for anyone — and a size-sensitive consumer can drop either and still keep
`vector_to_binary`, which costs ~12 KB.

## Verification

- 19 new unit tests, including a round trip against a GeoParquet file written by
  the upstream writer. CI's host-test step never covered `geolibre-wasm`; it does
  now.
- Driven in a real browser: the benchmark page loads the wasm-bindgen build and
  runs all three paths, which agree on feature count and coordinates.
- Real-world data: 3,666 US cities converted to ZSTD-compressed GeoParquet by
  our own CLI, then loaded through the page's file input — EPSG:4326 recovered
  from the `geo` metadata, `bbox` covering column correctly excluded from the
  attribute schema, all three paths agreeing.
- The Node smoke test now exercises both binary paths.

Docs updated in the root README and `npm/README.md`.
