### PR TITLE
chore(release): bump version to 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -1016,14 +1016,14 @@ dependencies = [
 
 [[package]]
 name = "geolibre-pmtiles"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "flate2",
 ]
 
 [[package]]
 name = "geolibre-tools"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "calamine",
  "flate2",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-wasm"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "1.2.0"
+version = "1.3.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-pmtiles/Cargo.toml
+++ b/crates/geolibre-pmtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-pmtiles"
-version = "1.2.0"
+version = "1.3.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "1.2.0"
+version = "1.3.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "1.2.0"
+version = "1.3.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolibre-wasm"
-version = "1.2.0"
+version = "1.3.0"
 description = "Run the GeoLibre / whitebox_next_gen geospatial tool suite (WASM/WASI) from Python."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/geolibre_wasm/__init__.py
+++ b/python/src/geolibre_wasm/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "runtime_path",
 ]
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"


### PR DESCRIPTION
Version bump only — no functional change.

**Minor, not patch**: #447 added public API surface to the browser library —
`vector_to_binary` and `vector_to_arrow_ipc` (plus their reprojecting variants),
`VectorBinary`, and GeoParquet joining the in-memory vector format list. Nothing
was removed or changed in behaviour, so 1.2.x → 1.3.0.

## Also reconciles a version drift

`v1.2.1` was tagged straight onto 68edb4e without a bump PR. `release.yml` syncs
the npm package version to the tag, so npm and PyPI published **1.2.1** while all
seven in-repo version strings stayed at **1.2.0** — which is why
`opengeos/GeoLibre` pins `geolibre-wasm: ^1.2.1` against a repo that says 1.2.0.
Moving everything to 1.3.0 puts the repo and the published artifacts back on one
number.

## Diff footprint

The usual eight files, nothing else:

- `crates/geolibre-{cli,tools,wasm,pmtiles}/Cargo.toml`
- `npm/package.json`
- `python/pyproject.toml`
- `python/src/geolibre_wasm/__init__.py`
- `Cargo.lock` (8 lines, via `cargo update -p … --precise 1.3.0`)

`cargo check --workspace` passes.

## After merge

Tag the squashed bump commit and push it — that triggers `release.yml`, which
builds both WASM artifacts, publishes to npm via Trusted Publishing, and cuts the
GitHub release:

```bash
git tag -a v1.3.0 -m "v1.3.0" <merged-sha>
git push origin v1.3.0
```
