### PR TITLE
fix(wasm): restore 14 tools that trapped in the browser, and report traps readably

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "wbcore"
 version = "0.1.1"
-source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
+source = "git+https://github.com/opengeos/whitebox-wasm#c0b6ec60bc533537874a9d7ac0ae9e642be1c591"
 dependencies = [
  "serde",
  "serde_json",
@@ -3608,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "wbgeotiff"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
+source = "git+https://github.com/opengeos/whitebox-wasm#c0b6ec60bc533537874a9d7ac0ae9e642be1c591"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -3627,7 +3627,7 @@ dependencies = [
 [[package]]
 name = "wbhdf"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
+source = "git+https://github.com/opengeos/whitebox-wasm#c0b6ec60bc533537874a9d7ac0ae9e642be1c591"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3638,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "wblidar"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
+source = "git+https://github.com/opengeos/whitebox-wasm#c0b6ec60bc533537874a9d7ac0ae9e642be1c591"
 dependencies = [
  "rayon",
  "wbhdf",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "wbprojection"
 version = "0.3.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
+source = "git+https://github.com/opengeos/whitebox-wasm#c0b6ec60bc533537874a9d7ac0ae9e642be1c591"
 dependencies = [
  "thiserror 1.0.69",
  "wide 1.5.0",
@@ -3658,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "wbraster"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
+source = "git+https://github.com/opengeos/whitebox-wasm#c0b6ec60bc533537874a9d7ac0ae9e642be1c591"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -3681,7 +3681,7 @@ dependencies = [
 [[package]]
 name = "wbspatialstats"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
+source = "git+https://github.com/opengeos/whitebox-wasm#c0b6ec60bc533537874a9d7ac0ae9e642be1c591"
 dependencies = [
  "log",
  "nalgebra",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "wbtools_oss"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
+source = "git+https://github.com/opengeos/whitebox-wasm#c0b6ec60bc533537874a9d7ac0ae9e642be1c591"
 dependencies = [
  "bincode",
  "chrono",
@@ -3726,7 +3726,7 @@ dependencies = [
 [[package]]
 name = "wbtopology"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
+source = "git+https://github.com/opengeos/whitebox-wasm#c0b6ec60bc533537874a9d7ac0ae9e642be1c591"
 dependencies = [
  "rayon",
  "robust",
@@ -3736,7 +3736,7 @@ dependencies = [
 [[package]]
 name = "wbvector"
 version = "0.1.4"
-source = "git+https://github.com/opengeos/whitebox-wasm#24173c5f720c3f5108bfd12c8b8065d7a8a805d6"
+source = "git+https://github.com/opengeos/whitebox-wasm#c0b6ec60bc533537874a9d7ac0ae9e642be1c591"
 dependencies = [
  "bytes",
  "flatbuffers 24.12.23",

--- a/demo/index.html
+++ b/demo/index.html
@@ -529,7 +529,9 @@
             dl.hidden = false;
           }
         } catch (e) {
-          $("output").textContent = "Error: " + (e && e.stack ? e.stack : e);
+          // Prefer the message: for a guest trap runTool folds the tool's own
+          // stderr into it, whereas the stack is just wasm-function offsets.
+          $("output").textContent = "Error: " + (e && e.message ? e.message : e);
         } finally {
           $("run").disabled = false;
         }

--- a/npm/tools.mjs
+++ b/npm/tools.mjs
@@ -132,6 +132,15 @@ async function materializeInput(value) {
   return new Uint8Array(value);
 }
 
+// Build a readable message for a guest trap out of what the tool printed to
+// stderr before aborting. `stdout` here is the shared stdout+stderr capture.
+function describeTrap(argv, err, stdout) {
+  const tool = argv[0] ?? "tool";
+  const tail = stdout.map((s) => s.trimEnd()).filter(Boolean).slice(-12);
+  const detail = tail.length ? `\n${tail.join("\n")}` : "";
+  return `${tool} crashed: ${err.message}${detail}`;
+}
+
 async function exec(argv, inputFiles) {
   const mod = await initTools();
   const inNames = new Set(Object.keys(inputFiles));
@@ -150,7 +159,14 @@ async function exec(argv, inputFiles) {
   const inst = await WebAssembly.instantiate(mod, { wasi_snapshot_preview1: wasi.wasiImport });
   let exitCode = 0;
   try { exitCode = wasi.start(inst); }
-  catch (e) { if (e && e.constructor && e.constructor.name === "WASIProcExit") exitCode = e.code; else throw e; }
+  catch (e) {
+    if (e && e.constructor && e.constructor.name === "WASIProcExit") exitCode = e.code;
+    // A guest trap (a Rust panic aborts to `unreachable`) surfaces as a bare
+    // RuntimeError whose stack is raw wasm-function offsets. The panic message
+    // was already written to stderr, so fold it into the error we rethrow —
+    // otherwise the caller only sees unreadable hex addresses.
+    else throw new Error(describeTrap(argv, e, stdout), { cause: e });
+  }
   // Collect every new file under /work, recursing into subdirectories so tools
   // that write a tree (e.g. raster_to_tiles' {z}/{x}/{y}.png) are surfaced too.
   // Keys are paths relative to /work (nested files use "/" separators).


### PR DESCRIPTION
Fixes #505.

## Root cause

`time_in_daylight` — and 13 other tools — aborted with a bare `unreachable`
trap the moment they ran in the browser. The cause was upstream, in
`whitebox-wasm`: nine worker fan-out sites called `std::thread::spawn` /
`scope.spawn` directly instead of going through the `dispatch_worker` helper
that exists precisely because wasm32 cannot spawn threads. On `wasm32-wasip1`
the spawn fails with `Unsupported` (errno 58), `std` unwraps that into a panic,
and the panic aborts to `unreachable`.

Fixed in opengeos/whitebox-wasm#13; this PR picks it up.

## Tools this restores

| Source | Tools |
| --- | --- |
| sky visibility | `horizon_angle`, `sky_view_factor`, `visibility_index`, `horizon_area`, `average_horizon_distance`, `time_in_daylight` |
| hydrology | `find_noflow_cells` |
| curvature | `plan_curvature`, `profile_curvature`, `tangential_curvature`, `total_curvature`, `mean_curvature`, `gaussian_curvature` |
| terrain analysis | `pennock_landform_classification` |

## Also: make a guest trap readable

The report contained nothing actionable — just wasm-function offsets:

```
Error: @https://opengeos.org/geolibre-rust/geolibre-cli.wasm:wasm-function[14315]:0x7705b7
...
```

That is because `exec()` rethrew the raw `RuntimeError` and dropped the stdout
it had already captured, even though the guest had written the real cause there
before aborting. `runTool` now folds that output into the rethrown error (the
original is kept as `cause`), and the demo prints `message` rather than `stack`,
which for a trap is only offsets. The same report would now read:

```
plan_curvature crashed: unreachable
running plan_curvature
reading input raster
thread 'main' (1) panicked at library/std/src/thread/scoped.rs:206:46:
failed to spawn thread: Os { code: 58, kind: Unsupported, message: "Not supported" }
```

## Verification

A `wasm32-wasip1` build driven through the same `@bjorn3/browser_wasi_shim` the
browser uses, before and after the upstream fix:

| | before | after |
| --- | --- | --- |
| all 14 tools above | trap | write output |
| `slope`, `aspect` (rayon controls) | ok | ok |

`node examples/node-demo.mjs` passes against the rebuilt runner.

## Known limitation

Serial is correct but not fast. On a 2880x1773 DEM, `time_in_daylight` (72
azimuth bins x a full-raster horizon trace each) did not finish inside 400s
under WASI, where before it failed instantly. That is inherent to wasm having
no threads; the horizon/daylight family is only practical on modest rasters in
the browser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages in the demo output when failures occur.
  * WASI guest crashes now display readable crash details instead of low-level WebAssembly errors.
  * Preserved the original underlying error for additional diagnostic context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->