### PR TITLE
chore(release): bump version to 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -1016,14 +1016,14 @@ dependencies = [
 
 [[package]]
 name = "geolibre-pmtiles"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "flate2",
 ]
 
 [[package]]
 name = "geolibre-tools"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "calamine",
  "flate2",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-wasm"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "1.3.0"
+version = "1.4.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-pmtiles/Cargo.toml
+++ b/crates/geolibre-pmtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-pmtiles"
-version = "1.3.0"
+version = "1.4.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "1.3.0"
+version = "1.4.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "1.3.0"
+version = "1.4.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolibre-wasm"
-version = "1.3.0"
+version = "1.4.0"
 description = "Run the GeoLibre / whitebox_next_gen geospatial tool suite (WASM/WASI) from Python."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/geolibre_wasm/__init__.py
+++ b/python/src/geolibre_wasm/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "runtime_path",
 ]
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"


### PR DESCRIPTION
Minor bump: **36 new tools** since v1.3.0, taking GeoLibre's own registry from 235 to **271** (**1003** tools in the CLI, counting the bundled whitebox suite).

| PR | Tools |
| --- | --- |
| #471 | 5 — trend prediction, summarize within, 3D ops |
| #490 | 18 — ArcGIS-inspired round 15 |
| #504 | 13 — ArcGIS-inspired round 16 |

Also carries #506, which fixes #505: **14 tools that could never run in the browser now can.** They aborted with an `unreachable` trap because their worker fan-outs called `std::thread::spawn`, which wasm32 cannot do — the sky-visibility family (including `time_in_daylight`), the six curvature tools, `find_noflow_cells`, and `pennock_landform_classification`. Fixed upstream in whitebox-wasm 0.5.1. Guest traps now also report the underlying panic message rather than raw wasm-function offsets.

Standard bump footprint: the seven in-repo version strings plus `Cargo.lock`, nothing else. All seven were consistently on 1.3.0, so there is no drift to reconcile this time.

Tag `v1.4.0` follows once this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the GeoLibre release version from **1.3.0** to **1.4.0** across supported packages and distributions.
  * Ensures consistent version reporting for CLI, WebAssembly, npm, and Python packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->