### PR TITLE
chore(release): bump version to 1.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -1016,14 +1016,14 @@ dependencies = [
 
 [[package]]
 name = "geolibre-pmtiles"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "flate2",
 ]
 
 [[package]]
 name = "geolibre-tools"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "calamine",
  "flate2",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-wasm"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "1.4.0"
+version = "1.4.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-pmtiles/Cargo.toml
+++ b/crates/geolibre-pmtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-pmtiles"
-version = "1.4.0"
+version = "1.4.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "1.4.0"
+version = "1.4.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "1.4.0"
+version = "1.4.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolibre-wasm"
-version = "1.4.0"
+version = "1.4.1"
 description = "Run the GeoLibre / whitebox_next_gen geospatial tool suite (WASM/WASI) from Python."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/geolibre_wasm/__init__.py
+++ b/python/src/geolibre_wasm/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "runtime_path",
 ]
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"


### PR DESCRIPTION
Patch bump: no new tools, one manifest-correctness fix since v1.4.0.

| PR | Change |
| --- | --- |
| #508 | correct mistyped boolean manifest params |

`wbcore::manifest_with_io_schema_json` infers a param's schema from keywords in its name and description. Five boolean flags across four whitebox tools — `buffer_vector`'s `dissolve`, `individual_tree_segmentation`'s `output_sidecar_csv`, `las_to_shapefile`'s `output_multipoint`, `lidar_tile`'s `output_laz_format`, and `lidar_tile_footprint`'s `output_hulls` — begin with "If true" or contain "output", so the inference typed them as dataset paths. A host UI building a form from `list_manifests()` rendered them as file pickers instead of checkboxes.

Explicit `geolibre_param_schemas` entries now short-circuit the inference for those four tools, which also corrects a dozen collateral mistypes (scalars read as raster inputs, an enum read as a file output, count params typed float instead of int).

Bumps `1.4.0 -> 1.4.1` across the four crates, `Cargo.lock`, `npm/package.json`, `python/pyproject.toml`, and `python/src/geolibre_wasm/__init__.py`. Tag `v1.4.1` after merge to publish to npm + PyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GeoLibre release version to **1.4.1** across the command-line tools, WebAssembly, npm, and Python packages.
  * Package metadata now consistently reports version **1.4.1**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->