### PR TITLE
chore(release): bump version to 1.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -1016,14 +1016,14 @@ dependencies = [
 
 [[package]]
 name = "geolibre-pmtiles"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "flate2",
 ]
 
 [[package]]
 name = "geolibre-tools"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "calamine",
  "flate2",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-wasm"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "1.4.1"
+version = "1.4.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-pmtiles/Cargo.toml
+++ b/crates/geolibre-pmtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-pmtiles"
-version = "1.4.1"
+version = "1.4.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "1.4.1"
+version = "1.4.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "1.4.1"
+version = "1.4.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolibre-wasm"
-version = "1.4.1"
+version = "1.4.2"
 description = "Run the GeoLibre / whitebox_next_gen geospatial tool suite (WASM/WASI) from Python."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/geolibre_wasm/__init__.py
+++ b/python/src/geolibre_wasm/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "runtime_path",
 ]
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"


### PR DESCRIPTION
Patch bump: no new tools, one manifest-correctness fix since v1.4.1.

  #510  type download_osm_vector's manifest params correctly

download_osm_vector reads no dataset input (it queries Overpass for a
bounding box), but keyword inference typed its `split_output_by_geometry`
checkbox as a vector input, so a host that resolves inputs before running
refused the tool outright. `provenance_output` was typed as an existing
JSON input rather than the sidecar the tool writes, `cache_dir` as a JSON
dataset rather than a directory path, and six params read with `as_u64`
came out float. An explicit `geolibre_param_schemas` entry now
short-circuits the inference for the tool, respelling the `filter_preset`
and `overpass_profile` enums that the inference had derived from the
descriptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package version to **1.4.2** across the CLI, tools, WebAssembly, npm, and Python distributions.
  * Published consistent version metadata across supported language ecosystems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->