### PR TITLE
chore(release): bump version to 1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "1.4.2"
+version = "1.5.0"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -1016,14 +1016,14 @@ dependencies = [
 
 [[package]]
 name = "geolibre-pmtiles"
-version = "1.4.2"
+version = "1.5.0"
 dependencies = [
  "flate2",
 ]
 
 [[package]]
 name = "geolibre-tools"
-version = "1.4.2"
+version = "1.5.0"
 dependencies = [
  "calamine",
  "flate2",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-wasm"
-version = "1.4.2"
+version = "1.5.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "1.4.2"
+version = "1.5.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-pmtiles/Cargo.toml
+++ b/crates/geolibre-pmtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-pmtiles"
-version = "1.4.2"
+version = "1.5.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "1.4.2"
+version = "1.5.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "1.4.2"
+version = "1.5.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolibre-wasm"
-version = "1.4.2"
+version = "1.5.0"
 description = "Run the GeoLibre / whitebox_next_gen geospatial tool suite (WASM/WASI) from Python."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/geolibre_wasm/__init__.py
+++ b/python/src/geolibre_wasm/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "runtime_path",
 ]
 
-__version__ = "1.4.2"
+__version__ = "1.5.0"


### PR DESCRIPTION
Bumps all seven version strings from `1.4.2` to `1.5.0` and regenerates `Cargo.lock`.

## Contents of this release

Since the last tag (`v1.4.3`):

- **#553** — round 19: 16 ArcGIS-inspired tools (cost paths, cube subset/merge, KML/glTF export, CMOD winds, regression kriging, diffusion cartogram). Registry 313 → 329.
- **#555** — line class support for `tabulate_intersection` + `summarize_nearby`, and the line-geometry conversion helpers deduplicated into `vector_common`.

A minor bump rather than a patch, since #553 adds 16 new tools to the registry.

## Note on version drift

`v1.4.3` was tagged directly on `8bedff2` **without bumping any version file** — the seven files still read `1.4.2` at that tag, so npm/PyPI published 1.4.3 while the repo stayed at 1.4.2. This PR bumps from the repo's `1.4.2` to `1.5.0`, which is the correct minor target from `1.4.3` as well, so the drift resolves itself here. Worth doing the bump PR before the tag next time so the two don't diverge.

## Verification

`cargo build -p geolibre-cli` → `geolibre-cli 1.5.0`. Diff footprint is the 8 expected files and nothing else.