### PR TITLE
chore(release): bump to 1.5.1 with the polygons_to_lines ring fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -1016,14 +1016,14 @@ dependencies = [
 
 [[package]]
 name = "geolibre-pmtiles"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "flate2",
 ]
 
 [[package]]
 name = "geolibre-tools"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "calamine",
  "flate2",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-wasm"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "wbcore"
 version = "0.1.1"
-source = "git+https://github.com/opengeos/whitebox-wasm#3e58af327eac2c82ac7f445ad4e672a5b5597438"
+source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
 dependencies = [
  "serde",
  "serde_json",
@@ -3608,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "wbgeotiff"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#3e58af327eac2c82ac7f445ad4e672a5b5597438"
+source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -3627,7 +3627,7 @@ dependencies = [
 [[package]]
 name = "wbhdf"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#3e58af327eac2c82ac7f445ad4e672a5b5597438"
+source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3638,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "wblidar"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#3e58af327eac2c82ac7f445ad4e672a5b5597438"
+source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
 dependencies = [
  "rayon",
  "wbhdf",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "wbprojection"
 version = "0.3.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#3e58af327eac2c82ac7f445ad4e672a5b5597438"
+source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
 dependencies = [
  "thiserror 1.0.69",
  "wide 1.5.0",
@@ -3658,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "wbraster"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#3e58af327eac2c82ac7f445ad4e672a5b5597438"
+source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -3681,7 +3681,7 @@ dependencies = [
 [[package]]
 name = "wbspatialstats"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#3e58af327eac2c82ac7f445ad4e672a5b5597438"
+source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
 dependencies = [
  "log",
  "nalgebra",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "wbtools_oss"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#3e58af327eac2c82ac7f445ad4e672a5b5597438"
+source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
 dependencies = [
  "bincode",
  "chrono",
@@ -3726,7 +3726,7 @@ dependencies = [
 [[package]]
 name = "wbtopology"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#3e58af327eac2c82ac7f445ad4e672a5b5597438"
+source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
 dependencies = [
  "rayon",
  "robust",
@@ -3736,7 +3736,7 @@ dependencies = [
 [[package]]
 name = "wbvector"
 version = "0.1.4"
-source = "git+https://github.com/opengeos/whitebox-wasm#3e58af327eac2c82ac7f445ad4e672a5b5597438"
+source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
 dependencies = [
  "bytes",
  "flatbuffers 24.12.23",

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "1.5.0"
+version = "1.5.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-pmtiles/Cargo.toml
+++ b/crates/geolibre-pmtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-pmtiles"
-version = "1.5.0"
+version = "1.5.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "1.5.0"
+version = "1.5.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "1.5.0"
+version = "1.5.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolibre-wasm"
-version = "1.5.0"
+version = "1.5.1"
 description = "Run the GeoLibre / whitebox_next_gen geospatial tool suite (WASM/WASI) from Python."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/geolibre_wasm/__init__.py
+++ b/python/src/geolibre_wasm/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "runtime_path",
 ]
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"


### PR DESCRIPTION
Pulls in opengeos/whitebox-wasm#18 and cuts 1.5.1.

## Why

Reported at opengeos/GeoLibre#1958 (discussion): converting a polygon to a polyline with **Polygons To Lines** leaves the last segment missing.

`wbvector::Ring` stores polygon rings open, without the closing duplicate vertex, and the GeoJSON reader strips the closing vertex on input. `polygons_to_lines` copied the ring coordinates straight into a `MultiLineString`, so the segment from the last vertex back to the first was never emitted. Two other tools walked rings the same way and left a matching gap: `vector_lines_to_raster` (which documents polygon input and burns boundaries) and the watershed boundary rasterizer in `hydrology`.

## What changed

`cargo update` moves the 10 `whitebox-wasm` git crates from `3e58af32` to `ccb491a4`, plus the usual version bump across the crates, `npm/package.json`, and the Python package.

## Verification

`geolibre-cli` built from this lockfile, on a square and a polygon with a hole:

```
square    [[[0,0],[10,0],[10,10],[0,10],[0,0]]]
with_hole [[[20,0],[30,0],[30,10],[20,10],[20,0]], [[22,2],[24,2],[24,4],[22,4],[22,2]]]
```

Both rings now close. Before the fix the square came back as `[[0,0],[10,0],[10,10],[0,10]]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions from 1.5.0 to 1.5.1 across the CLI, tools, WebAssembly, PMTiles, npm, and Python distributions.
  * No user-facing functionality or API changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->