### PR TITLE
chore(release): bump to 1.5.2 with the attribute-field and dissolve fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-cli"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "geolibre-tools",
  "serde_json",
@@ -1016,14 +1016,14 @@ dependencies = [
 
 [[package]]
 name = "geolibre-pmtiles"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "flate2",
 ]
 
 [[package]]
 name = "geolibre-tools"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "calamine",
  "flate2",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-wasm"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "wbcore"
 version = "0.1.1"
-source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
+source = "git+https://github.com/opengeos/whitebox-wasm#3d1ddeebc6052f4f54f0f8c0af5207a4efa7def3"
 dependencies = [
  "serde",
  "serde_json",
@@ -3608,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "wbgeotiff"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
+source = "git+https://github.com/opengeos/whitebox-wasm#3d1ddeebc6052f4f54f0f8c0af5207a4efa7def3"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -3627,7 +3627,7 @@ dependencies = [
 [[package]]
 name = "wbhdf"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
+source = "git+https://github.com/opengeos/whitebox-wasm#3d1ddeebc6052f4f54f0f8c0af5207a4efa7def3"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3638,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "wblidar"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
+source = "git+https://github.com/opengeos/whitebox-wasm#3d1ddeebc6052f4f54f0f8c0af5207a4efa7def3"
 dependencies = [
  "rayon",
  "wbhdf",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "wbprojection"
 version = "0.3.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
+source = "git+https://github.com/opengeos/whitebox-wasm#3d1ddeebc6052f4f54f0f8c0af5207a4efa7def3"
 dependencies = [
  "thiserror 1.0.69",
  "wide 1.5.0",
@@ -3658,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "wbraster"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
+source = "git+https://github.com/opengeos/whitebox-wasm#3d1ddeebc6052f4f54f0f8c0af5207a4efa7def3"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -3681,7 +3681,7 @@ dependencies = [
 [[package]]
 name = "wbspatialstats"
 version = "0.1.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
+source = "git+https://github.com/opengeos/whitebox-wasm#3d1ddeebc6052f4f54f0f8c0af5207a4efa7def3"
 dependencies = [
  "log",
  "nalgebra",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "wbtools_oss"
 version = "0.1.2"
-source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
+source = "git+https://github.com/opengeos/whitebox-wasm#3d1ddeebc6052f4f54f0f8c0af5207a4efa7def3"
 dependencies = [
  "bincode",
  "chrono",
@@ -3726,7 +3726,7 @@ dependencies = [
 [[package]]
 name = "wbtopology"
 version = "0.2.0"
-source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
+source = "git+https://github.com/opengeos/whitebox-wasm#3d1ddeebc6052f4f54f0f8c0af5207a4efa7def3"
 dependencies = [
  "rayon",
  "robust",
@@ -3736,7 +3736,7 @@ dependencies = [
 [[package]]
 name = "wbvector"
 version = "0.1.4"
-source = "git+https://github.com/opengeos/whitebox-wasm#ccb491a4c866d8c97ca8eebe3cebae6030b82a50"
+source = "git+https://github.com/opengeos/whitebox-wasm#3d1ddeebc6052f4f54f0f8c0af5207a4efa7def3"
 dependencies = [
  "bytes",
  "flatbuffers 24.12.23",

--- a/crates/geolibre-cli/Cargo.toml
+++ b/crates/geolibre-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-cli"
-version = "1.5.1"
+version = "1.5.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-pmtiles/Cargo.toml
+++ b/crates/geolibre-pmtiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-pmtiles"
-version = "1.5.1"
+version = "1.5.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-tools/Cargo.toml
+++ b/crates/geolibre-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-tools"
-version = "1.5.1"
+version = "1.5.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/geolibre-wasm/Cargo.toml
+++ b/crates/geolibre-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-wasm"
-version = "1.5.1"
+version = "1.5.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre-wasm",
   "type": "module",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Pure-Rust geospatial toolkit (whitebox_next_gen) compiled to WebAssembly (WASI) for GeoLibre's in-browser tool execution",
   "license": "MIT",
   "repository": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolibre-wasm"
-version = "1.5.1"
+version = "1.5.2"
 description = "Run the GeoLibre / whitebox_next_gen geospatial tool suite (WASM/WASI) from Python."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/src/geolibre_wasm/__init__.py
+++ b/python/src/geolibre_wasm/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "runtime_path",
 ]
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"


### PR DESCRIPTION
## Summary

Pulls in three opengeos/whitebox-wasm fixes for https://github.com/opengeos/GeoLibre/discussions/1977, where the reporter cannot enter a grouping field in the Whitebox Dissolve dialog and gets 48 features for 12 attribute values.

- **opengeos/whitebox-wasm#19** — a `*_field`/`*_attribute` parameter names a column, so it infers as a string. The inference read the description, which describes the data the column *indexes*: `dissolve.dissolve_field` ("Optional attribute field used to dissolve **polygons** within groups") became a vector input, the network tools' `one_way_field` ("…legacy **boolean** values") became a checkbox, and `classify_objects_*.class_field` ("…in training **CSV**") became a file picker. A host UI offered a file dialog or a tick box where a column name belongs.
- **opengeos/whitebox-wasm#20** — `dissolve` emits one feature per dissolve group. Parts of a group that share an attribute value but no boundary were emitted separately, so the output had more features than the field has values.
- **opengeos/whitebox-wasm#21** — GeoJSON/TopoJSON strings decode as UTF-8. Both parsers pushed each byte as a Latin-1 code point and re-encoded it, so `Céréales` came back as `CÃ©rÃ©ales` from every tool, compounding on each pass.

## Verification

`geolibre manifests`, diffed against the manifests the published `geolibre-wasm@1.5.1` emits:

```
changed params: 54  tools: 28
Counter({('input', 'string'): 43, ('bool', 'string'): 11})
non-string results: []
```

Exactly the intended params move, all to `string`, and nothing else changes. `dissolve.dissolve_field` is now `{'kind': 'string'}`.

End to end on the reporter's `OTEX-Cher-WGS.geojson` (290 communes, 12 `OTEX` values), via a native build of the same crates:

```
$ whitebox dissolve --input=otex.geojson --dissolve_field=OTEX --output=out.geojson
features: 12
Counter({'MultiPolygon': 7, 'Polygon': 5})
```

Was 48 features before. A clean-UTF-8 fixture round-trips `Céréales` intact, where the pre-#21 binary writes `CÃ©rÃ©ales`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release version from 1.5.1 to 1.5.2 across the CLI, PMTiles, tools, WebAssembly, npm, and Python packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->